### PR TITLE
Changing memory management to fix performance issue

### DIFF
--- a/src/core/storage/data_reader.cpp
+++ b/src/core/storage/data_reader.cpp
@@ -189,6 +189,8 @@ Ret DataReader::init_(const std::string& path, std::unique_ptr<DataReader> delta
         ids_ = nullptr;
         cosine_inv_norms_ = nullptr;
         deleted_ids_ = nullptr;
+        ids_buf_.clear();
+        cosine_inv_norms_buf_.clear();
         size_ = 0;
         stride_ = 0;
         return Ret(message);
@@ -248,11 +250,44 @@ Ret DataReader::init_(const std::string& path, std::unique_ptr<DataReader> delta
         }
     }
 
-    cosine_inv_norms_ = ids_layout.cosine_inv_norms_bytes == 0
-        ? nullptr
-        : reinterpret_cast<const float*>(map_ + ids_layout.cosine_inv_norms_offset);
-    ids_ = reinterpret_cast<const uint64_t*>(map_ + ids_layout.ids_offset);
-    deleted_ids_ = ids_ + count;
+    try {
+        // Buffer IDs (active + deleted) into heap memory to avoid page faults
+        // during scans that alternate between the vector region and the IDs region.
+        const size_t total_ids = count + deleted_count;
+        if (total_ids > 0) {
+            ids_buf_.resize(total_ids);
+            std::memcpy(ids_buf_.data(), map_ + ids_layout.ids_offset, total_ids * sizeof(uint64_t));
+            ids_ = ids_buf_.data();
+            deleted_ids_ = ids_buf_.data() + count;
+        } else {
+            ids_ = reinterpret_cast<const uint64_t*>(map_ + ids_layout.ids_offset);
+            deleted_ids_ = ids_ + count;
+        }
+
+        // Buffer cosine inverse norms for the same reason: the norms section sits
+        // far from the vector data and would cause thrashing on every scan iteration.
+        if (ids_layout.cosine_inv_norms_bytes > 0) {
+            cosine_inv_norms_buf_.resize(count);
+            std::memcpy(cosine_inv_norms_buf_.data(),
+                        map_ + ids_layout.cosine_inv_norms_offset,
+                        count * sizeof(float));
+            cosine_inv_norms_ = cosine_inv_norms_buf_.data();
+        } else {
+            cosine_inv_norms_ = nullptr;
+        }
+
+        // Release mmap pages for the metadata region (norms + IDs) since the data
+        // now lives in heap buffers. Page-align the start to satisfy madvise.
+        const size_t meta_start = static_cast<size_t>(hdr_->data_offset) + ids_layout.vectors_bytes;
+        const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+        const size_t aligned_start = align_up<size_t>(meta_start, page_size);
+        if (aligned_start < map_len_) {
+            madvise(const_cast<uint8_t*>(map_) + aligned_start,
+                    map_len_ - aligned_start, MADV_DONTNEED);
+        }
+    } catch (const std::exception& ex) {
+        return fail(std::string("DataReader: failed to initialize metadata cache: ") + ex.what());
+    }
     delta_  = std::move(delta);
 
     if (delta_) {

--- a/src/core/storage/data_reader.h
+++ b/src/core/storage/data_reader.h
@@ -98,6 +98,8 @@ private:
     const uint64_t*          ids_     = nullptr; // cached pointer to the ids section
     const float*             cosine_inv_norms_ = nullptr; // cached pointer to optional cosine inverse norms
     const uint64_t*          deleted_ids_ = nullptr; // cached pointer to the deleted ids section
+    std::vector<uint64_t>    ids_buf_;             // heap buffer for ids + deleted_ids
+    std::vector<float>       cosine_inv_norms_buf_; // heap buffer for cosine inverse norms
     DataType                 type_    = DataType::f32;
     size_t                   size_    = 0;        // size of one vector in bytes
     size_t                   stride_  = 0;        // bytes between persisted vectors

--- a/tests/compute_perf/x86_64_2M_f32_4threads.txt
+++ b/tests/compute_perf/x86_64_2M_f32_4threads.txt
@@ -1,0 +1,429 @@
+Test results after fixing performance issue.
+
+Before the fix same test produced the following results:
+
+--- PERFORMANCE SUMMARY (avg time) ---
+engine  | cos        | l2        | dot
+--------+------------+-----------+----------
+scalar  | 15.949639s | 0.967366s | 0.846317s
+auto    | 15.828813s | 0.377128s | 0.359322s
+highway | 15.825882s | 0.358454s | 0.361439s
+numkong | 15.810304s | 0.350717s | 0.361225s
+
+
+
+
+mpopov@build-x86-64:~/projects/sketch2/tests/compute_perf$ ./driver.sh
+[driver] performance test configuration
+[driver]   config_root=/mnt/test/sketch2_COMPUTE_PERF.tz2lUr
+[driver]   skip_init=0
+[driver]   dataset=perf_test
+[driver]   dims=1536
+[driver]   count=2000000
+[driver]   repeat=10
+[driver]   k=20
+[driver]   type=f32
+[driver]   dist=cos,l2,dot
+[driver]   range_size=200000
+[driver]   engines=scalar,auto,highway,numkong
+[driver]   benchmarks=scan,kernel
+[driver]   kernel_iterations=200000
+[driver]   kernel_warmup_iterations=5000
+[driver]   kernel_repeats=7
+[driver]   cleanup=0
+[driver]   dummy_calc=0
+[driver]   diag_dir=/mnt/test/sketch2_COMPUTE_PERF.tz2lUr/logs/diag
+[driver]   core_limit=unlimited
+[driver]   core_pattern=|/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -F%F -- %E
+[driver] preparing dataset for dist=cos
+[initializer] warning: db_dir /mnt/test/sketch2_COMPUTE_PERF.tz2lUr exists but does not look like a harness temp dir or Sketch2 dir; not wiping for safety
+18429 2026-04-09 23:14:20 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18429 2026-04-09 23:14:20 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+[initializer] creating dataset perf_test_cos with dist=cos
+[initializer] generating 2000000 vectors using sketch2.generate_test_data (native generator)
+[initializer] calculating ground truth for cos
+[initializer] dataset perf_test_cos is ready
+[initializer] initialization complete
+[driver] initializer finished successfully and verified dataset for dist=cos
+[driver] benchmarks engine=scalar dist=cos
+18454 2026-04-09 23:16:42 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18454 2026-04-09 23:16:42 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18454 2026-04-09 23:16:42 INFO     Compute engine is set in env var: scalar
+[runner] benchmarking dataset perf_test_cos with engine=scalar
+[runner] loading ground truth for cos...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    scalar
+Metric:            cos
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    scalar
+Kernel Case:      dist avg=2502.845ns min=2502.666ns max=2503.140ns
+Kernel Case:      dot avg=1247.976ns min=1247.577ns max=1249.722ns
+Kernel Case:      squared_norm avg=1241.000ns min=1236.710ns max=1265.812ns
+Kernel Case:      dist_with_query_norm avg=1260.612ns min=1260.395ns max=1260.921ns
+-------------------------------
+[runner] warm-up iteration for cos
+[runner] running 10 iterations for cos
+--- PERFORMANCE REPORT ---
+Compute Engine: scalar
+Metric:         cos
+Iterations:     10
+Min Time:       0.832017s
+Max Time:       0.836504s
+Avg Time:       0.833593s
+--------------------------
+[driver] benchmarks engine=auto dist=cos
+18465 2026-04-09 23:17:00 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18465 2026-04-09 23:17:00 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+[runner] benchmarking dataset perf_test_cos with engine=auto
+[runner] loading ground truth for cos...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    auto
+Metric:            cos
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+Kernel Case:      dist avg=155.442ns min=155.016ns max=156.242ns
+Kernel Case:      dot avg=74.731ns min=74.257ns max=75.216ns
+Kernel Case:      squared_norm avg=30.017ns min=29.792ns max=30.186ns
+Kernel Case:      dist_with_query_norm avg=119.853ns min=119.330ns max=120.175ns
+-------------------------------
+[runner] warm-up iteration for cos
+[runner] running 10 iterations for cos
+--- PERFORMANCE REPORT ---
+Compute Engine: auto
+Metric:         cos
+Iterations:     10
+Min Time:       0.317925s
+Max Time:       0.340179s
+Avg Time:       0.330868s
+--------------------------
+[driver] benchmarks engine=highway dist=cos
+18479 2026-04-09 23:17:04 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18479 2026-04-09 23:17:04 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18479 2026-04-09 23:17:04 INFO     Compute engine is set in env var: highway
+[runner] benchmarking dataset perf_test_cos with engine=highway
+[runner] loading ground truth for cos...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    highway
+Metric:            cos
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+Kernel Case:      dist avg=110.779ns min=110.526ns max=111.420ns
+Kernel Case:      dot avg=78.553ns min=77.843ns max=80.044ns
+Kernel Case:      squared_norm avg=77.045ns min=76.835ns max=77.470ns
+Kernel Case:      dist_with_query_norm avg=95.546ns min=95.397ns max=95.864ns
+-------------------------------
+[runner] warm-up iteration for cos
+[runner] running 10 iterations for cos
+--- PERFORMANCE REPORT ---
+Compute Engine: highway
+Metric:         cos
+Iterations:     10
+Min Time:       0.334931s
+Max Time:       0.399985s
+Avg Time:       0.362653s
+--------------------------
+[driver] benchmarks engine=numkong dist=cos
+18490 2026-04-09 23:17:09 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18490 2026-04-09 23:17:09 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18490 2026-04-09 23:17:09 INFO     Compute engine is set in env var: numkong
+[runner] benchmarking dataset perf_test_cos with engine=numkong
+[runner] loading ground truth for cos...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    numkong
+Metric:            cos
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+NumKong Backend:   skylake
+Kernel Case:      dist avg=241.986ns min=241.553ns max=242.563ns
+Kernel Case:      dot avg=204.366ns min=204.121ns max=204.533ns
+Kernel Case:      squared_norm avg=141.536ns min=141.189ns max=141.891ns
+Kernel Case:      dist_with_query_norm avg=1260.941ns min=1260.581ns max=1262.019ns
+-------------------------------
+[runner] warm-up iteration for cos
+[runner] running 10 iterations for cos
+--- PERFORMANCE REPORT ---
+Compute Engine: numkong
+Metric:         cos
+Iterations:     10
+Min Time:       0.324644s
+Max Time:       0.371885s
+Avg Time:       0.356365s
+--------------------------
+[driver] removing dataset artifacts for dist=cos
+[driver] preparing dataset for dist=l2
+[initializer] preserving db_dir for single-metric init: /mnt/test/sketch2_COMPUTE_PERF.tz2lUr
+18504 2026-04-09 23:17:16 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18504 2026-04-09 23:17:16 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18504 2026-04-09 23:17:16 INFO     Compute engine is set in env var: numkong
+[initializer] creating dataset perf_test_l2 with dist=l2
+[initializer] generating 2000000 vectors using sketch2.generate_test_data (native generator)
+[initializer] calculating ground truth for l2
+[initializer] dataset perf_test_l2 is ready
+[initializer] initialization complete
+[driver] initializer finished successfully and verified dataset for dist=l2
+[driver] benchmarks engine=scalar dist=l2
+18520 2026-04-09 23:20:01 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18520 2026-04-09 23:20:01 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18520 2026-04-09 23:20:01 INFO     Compute engine is set in env var: scalar
+[runner] benchmarking dataset perf_test_l2 with engine=scalar
+[runner] loading ground truth for l2...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    scalar
+Metric:            l2
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    scalar
+Kernel Case:      dist avg=1251.192ns min=1251.009ns max=1251.748ns
+-------------------------------
+[runner] warm-up iteration for l2
+[runner] running 10 iterations for l2
+--- PERFORMANCE REPORT ---
+Compute Engine: scalar
+Metric:         l2
+Iterations:     10
+Min Time:       0.965342s
+Max Time:       0.970626s
+Avg Time:       0.967889s
+--------------------------
+[driver] benchmarks engine=auto dist=l2
+18531 2026-04-09 23:20:13 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18531 2026-04-09 23:20:13 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+[runner] benchmarking dataset perf_test_l2 with engine=auto
+[runner] loading ground truth for l2...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    auto
+Metric:            l2
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+Kernel Case:      dist avg=74.615ns min=74.293ns max=74.804ns
+-------------------------------
+[runner] warm-up iteration for l2
+[runner] running 10 iterations for l2
+--- PERFORMANCE REPORT ---
+Compute Engine: auto
+Metric:         l2
+Iterations:     10
+Min Time:       0.337455s
+Max Time:       0.364083s
+Avg Time:       0.348772s
+--------------------------
+[driver] benchmarks engine=highway dist=l2
+18542 2026-04-09 23:20:17 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18542 2026-04-09 23:20:17 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18542 2026-04-09 23:20:17 INFO     Compute engine is set in env var: highway
+[runner] benchmarking dataset perf_test_l2 with engine=highway
+[runner] loading ground truth for l2...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    highway
+Metric:            l2
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+Kernel Case:      dist avg=85.562ns min=85.209ns max=86.064ns
+-------------------------------
+[runner] warm-up iteration for l2
+[runner] running 10 iterations for l2
+--- PERFORMANCE REPORT ---
+Compute Engine: highway
+Metric:         l2
+Iterations:     10
+Min Time:       0.342514s
+Max Time:       0.359375s
+Avg Time:       0.351846s
+--------------------------
+[driver] benchmarks engine=numkong dist=l2
+18556 2026-04-09 23:20:22 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18556 2026-04-09 23:20:22 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18556 2026-04-09 23:20:22 INFO     Compute engine is set in env var: numkong
+[runner] benchmarking dataset perf_test_l2 with engine=numkong
+[runner] loading ground truth for l2...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    numkong
+Metric:            l2
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+NumKong Backend:   skylake
+Kernel Case:      dist avg=211.963ns min=211.694ns max=212.251ns
+-------------------------------
+[runner] warm-up iteration for l2
+[runner] running 10 iterations for l2
+--- PERFORMANCE REPORT ---
+Compute Engine: numkong
+Metric:         l2
+Iterations:     10
+Min Time:       0.334408s
+Max Time:       0.360445s
+Avg Time:       0.345028s
+--------------------------
+[driver] removing dataset artifacts for dist=l2
+[driver] preparing dataset for dist=dot
+[initializer] preserving db_dir for single-metric init: /mnt/test/sketch2_COMPUTE_PERF.tz2lUr
+18570 2026-04-09 23:20:26 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18570 2026-04-09 23:20:26 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18570 2026-04-09 23:20:26 INFO     Compute engine is set in env var: numkong
+[initializer] creating dataset perf_test_dot with dist=dot
+[initializer] generating 2000000 vectors using sketch2.generate_test_data (native generator)
+[initializer] calculating ground truth for dot
+[initializer] dataset perf_test_dot is ready
+[initializer] initialization complete
+[driver] initializer finished successfully and verified dataset for dist=dot
+[driver] benchmarks engine=scalar dist=dot
+18594 2026-04-09 23:23:10 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18594 2026-04-09 23:23:10 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18594 2026-04-09 23:23:10 INFO     Compute engine is set in env var: scalar
+[runner] benchmarking dataset perf_test_dot with engine=scalar
+[runner] loading ground truth for dot...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    scalar
+Metric:            dot
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    scalar
+Kernel Case:      dist avg=1248.277ns min=1247.967ns max=1248.926ns
+-------------------------------
+[runner] warm-up iteration for dot
+[runner] running 10 iterations for dot
+--- PERFORMANCE REPORT ---
+Compute Engine: scalar
+Metric:         dot
+Iterations:     10
+Min Time:       0.969424s
+Max Time:       0.974178s
+Avg Time:       0.971364s
+--------------------------
+[driver] benchmarks engine=auto dist=dot
+18607 2026-04-09 23:23:23 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18607 2026-04-09 23:23:23 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+[runner] benchmarking dataset perf_test_dot with engine=auto
+[runner] loading ground truth for dot...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    auto
+Metric:            dot
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+Kernel Case:      dist avg=74.460ns min=74.086ns max=74.892ns
+-------------------------------
+[runner] warm-up iteration for dot
+[runner] running 10 iterations for dot
+--- PERFORMANCE REPORT ---
+Compute Engine: auto
+Metric:         dot
+Iterations:     10
+Min Time:       0.343037s
+Max Time:       0.368907s
+Avg Time:       0.358408s
+--------------------------
+[driver] benchmarks engine=highway dist=dot
+18618 2026-04-09 23:23:27 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18618 2026-04-09 23:23:27 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18618 2026-04-09 23:23:27 INFO     Compute engine is set in env var: highway
+[runner] benchmarking dataset perf_test_dot with engine=highway
+[runner] loading ground truth for dot...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    highway
+Metric:            dot
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+Kernel Case:      dist avg=77.880ns min=77.573ns max=78.236ns
+-------------------------------
+[runner] warm-up iteration for dot
+[runner] running 10 iterations for dot
+--- PERFORMANCE REPORT ---
+Compute Engine: highway
+Metric:         dot
+Iterations:     10
+Min Time:       0.349769s
+Max Time:       0.402539s
+Avg Time:       0.374724s
+--------------------------
+[driver] benchmarks engine=numkong dist=dot
+18629 2026-04-09 23:23:32 INFO     Compute backend set to 'avx512_vnni' because auto-detected AVX-512 VNNI because the required AVX-512F/BW/VL/VNNI CPU features are present.
+18629 2026-04-09 23:23:32 INFO     Initialize from file /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/config.ini
+18629 2026-04-09 23:23:32 INFO     Compute engine is set in env var: numkong
+[runner] benchmarking dataset perf_test_dot with engine=numkong
+[runner] loading ground truth for dot...
+--- KERNEL PERFORMANCE REPORT ---
+Compute Engine:    numkong
+Metric:            dot
+Type:              f32
+Dim:               1536
+Warmup Iterations: 5000
+Iterations:        200000
+Repeats:           7
+Active Backend:    avx512_vnni
+NumKong Backend:   skylake
+Kernel Case:      dist avg=204.496ns min=204.064ns max=204.997ns
+-------------------------------
+[runner] warm-up iteration for dot
+[runner] running 10 iterations for dot
+--- PERFORMANCE REPORT ---
+Compute Engine: numkong
+Metric:         dot
+Iterations:     10
+Min Time:       0.349327s
+Max Time:       0.374477s
+Avg Time:       0.358960s
+--------------------------
+[driver] removing dataset artifacts for dist=dot
+[driver] generating summary report...
+--- PERFORMANCE SUMMARY (avg time) ---
+engine  | cos       | l2        | dot
+--------+-----------+-----------+----------
+scalar  | 0.833593s | 0.967889s | 0.971364s
+auto    | 0.330868s | 0.348772s | 0.358408s
+highway | 0.362653s | 0.351846s | 0.374724s
+numkong | 0.356365s | 0.345028s | 0.358960s
+--------------------------------------
+--- KERNEL SUMMARY (metric avg ns/call) ---
+engine  | cos        | l2         | dot
+--------+------------+------------+-----------
+scalar  | 2502.845ns | 1251.192ns | 1248.277ns
+auto    | 155.442ns  | 74.615ns   | 74.460ns
+highway | 110.779ns  | 85.562ns   | 77.880ns
+numkong | 241.986ns  | 211.963ns  | 204.496ns
+-----------------------------------------
+[driver] performance test completed
+[driver] logs available in /mnt/test/sketch2_COMPUTE_PERF.tz2lUr/logs
+[driver] preserving /mnt/test/sketch2_COMPUTE_PERF.tz2lUr (set COMPUTE_PERF_TEST_CLEANUP=1 to remove it automatically)
+


### PR DESCRIPTION

mpopov@build-x86-64:~/projects/sketch2/tests/compute_perf$ ./driver.sh
[driver] performance test configuration
[driver]   config_root=/mnt/test/sketch2_COMPUTE_PERF.LUP9Jy
[driver]   skip_init=0
[driver]   dataset=perf_test
[driver]   dims=1536
[driver]   count=2000000
[driver]   repeat=10
[driver]   k=20
[driver]   type=f32
[driver]   dist=cos,l2,dot
[driver]   range_size=200000
[driver]   engines=scalar,auto,highway,numkong
[driver]   benchmarks=scan,kernel
[driver]   kernel_iterations=200000
[driver]   kernel_warmup_iterations=5000
[driver]   kernel_repeats=7
[driver]   cleanup=0
[driver]   dummy_calc=0
[driver]   diag_dir=/mnt/test/sketch2_COMPUTE_PERF.LUP9Jy/logs/diag
[driver]   core_limit=unlimited
[driver]   core_pattern=|/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -F%F -- %E

...

```
--- PERFORMANCE SUMMARY (avg time) ---
engine  | cos        | l2        | dot
--------+------------+-----------+----------
scalar  | 15.949639s | 0.967366s | 0.846317s
auto    | 15.828813s | 0.377128s | 0.359322s
highway | 15.825882s | 0.358454s | 0.361439s
numkong | 15.810304s | 0.350717s | 0.361225s
--------------------------------------
--- KERNEL SUMMARY (metric avg ns/call) ---
engine  | cos        | l2         | dot
--------+------------+------------+-----------
scalar  | 2503.010ns | 1251.233ns | 1248.643ns
auto    | 155.354ns  | 74.720ns   | 74.577ns
highway | 110.485ns  | 85.376ns   | 77.709ns
numkong | 242.085ns  | 211.918ns  | 204.459ns
-----------------------------------------
```

I am concerned about "cos" times. There are no difference between "scalar" time and other times. It means time was not dominated by CPU. If not CPU, then it must be I/O. We have very big files mapped to memory. They configured for sequential scanning. But vectors data are in one part of a mapped file and additional precalculated values are in another part of the file. I suspect this data layout may cause memory thrashing and excessive I/O that dominates this test's "cos" calculations. What do you think?

Claude:
● Your hypothesis is confirmed. The code and data layout make this clear:

  The Problem

  The data file layout (data_file_layout.h) places sections sequentially:

  [Header] [All Vectors (~12.8 GB)] [Cosine Inv Norms (~8 MB)] [IDs] ...

  For 2M vectors × 1536 dims × f32: the vectors span ~12.8 GB, and the norms sit right after.

  During a cosine scan, each iteration does:
  1. Read it.data() — vector at offset index × stride (within first ~12.8 GB)
  2. Read it.cosine_inv_norm() — norm at offset ~12.8 GB + index × 4

  This bounces between two regions ~12.8 GB apart on every single vector. Meanwhile, the entire file is mapped with MADV_SEQUENTIAL, which tells the OS to aggressively read-ahead in one direction — exactly wrong for this
  ping-pong pattern.

  L2 and dot product only access the vector region — pure sequential scan through contiguous memory, which is why they benefit massively from SIMD and the sequential madvise hint.

  Why SIMD Doesn't Help for Cos

  The ~15.8s is almost entirely I/O (page faults, TLB misses). The actual distance computation is negligible compared to the cost of paging in data from two distant regions. SIMD optimizes the compute, but compute isn't the
  bottleneck.

  The kernel benchmark confirms this — at the kernel level (data already in cache), cosine does show SIMD speedup: scalar 2503ns vs highway 110ns.

---------------------------------------------------
How about reading "norms" into a memory buffer and accessing them in the buffer instead of a region of mapped file?

● That's a great pragmatic fix — simple, low-risk, and directly addresses the problem. The norms are only count × 4 bytes = ~8 MB for 2M vectors. That fits trivially in RAM and eliminates the page-fault ping-pong entirely.

  Advantages over the other options:

  - No file format change — unlike interleaving norms into the stride, this is purely a read-path optimization
  - Trivial to implement — allocate a buffer, memcpy from the mmap region once, point cosine_inv_norms_ at the buffer instead
  - Guaranteed hot — the sequential memcpy pre-faults all norm pages in one pass, then the buffer stays in RAM with no risk of the OS evicting it due to MADV_SEQUENTIAL pressure from the vector scan
  - No extra FLOPs — unlike computing norms inline

  The scan then becomes purely sequential through the vector region (as it already is for L2/dot), with norm lookups hitting an 8 MB buffer that sits comfortably in L3 cache on most machines.


----------------------------------------------------
There is an additional problem. In some scenarios scanning of vectors can be filtered by checking is vector's id in index defined by a bitset. In this case we have a similar problem of accessing different parts of a mapped file. Did I get it right?

● Yes, exactly the same problem. Look at the scan loop in scanner_ex.cpp:142-148:

  if (bitset != nullptr) {
      const uint64_t id = it.id();       // <-- jump to IDs region
      // ... check bitset ...
      if (...) continue;
  }
  push_result(heap, count, it.id(), score(it));  // <-- score accesses vector region

  And it.id() resolves to ids_[index_] in data_reader.cpp:72, where ids_ points to the IDs section of the mmap — which sits after both vectors and norms:

  [Vectors ~12.8 GB] [Norms ~8 MB] [IDs ~16 MB] ...

  So with bitset filtering, every iteration hits three distant regions:

  1. IDs at offset ~12.8 GB — to check the bitset filter
  2. Vector data at offset index × stride — for the distance computation
  3. Norms at offset ~12.8 GB — for cosine (the problem we already identified)

  Even for L2/dot with bitset filtering, you'd be bouncing between the vector region and the IDs region on every iteration. It's less dramatic than the cosine case (two regions vs three, and vector compute dominates more for
  L2/dot), but the same class of problem.

  The same fix applies — buffer the IDs array into memory alongside the norms. At count × 8 bytes = ~16 MB for 2M vectors, it's still trivially small. Then the scan only touches the vector region in the mmap, which is truly
  sequential.

-------------------------------------------------------
So basically we can read norms and ids into a dedicated buffer then mark the file region madvise(NOT_NEEDED) to release memory. In this case we will not have memory duplication for the same data,.

● Right. MADV_DONTNEED tells the kernel to drop those pages from the page cache immediately. Since you've already copied the data into your buffer, the mmap pages are just dead weight — releasing them avoids any duplication.

  The sequence would be:

  1. memcpy norms and IDs from the mmap into buffers
  2. madvise(MADV_DONTNEED) on the norms+IDs region of the mmap
  3. Point cosine_inv_norms_ and ids_ at the buffers instead

  After that, the only mmap pages the kernel needs to maintain are the vector data region, which gets a clean sequential scan. The norms/IDs pages get reclaimed, so total memory usage stays roughly the same — you just moved
  ~24 MB from kernel page cache into userspace buffers.

  One subtlety: ids_ is also accessed outside of scanning (lookups by index, binary search, etc.), so those code paths will transparently benefit too since the buffer is always hot in memory.

