### PR TITLE
20260419 store norm next to vector

### DIFF
--- a/src/core/compute/compute_engine.h
+++ b/src/core/compute/compute_engine.h
@@ -33,10 +33,14 @@ using ComputeSquaredNormFn      = double (*)(const uint8_t*, size_t);
 using ComputeDotFn              = double (*)(const uint8_t*, const uint8_t*, size_t);
 
 // Holds all resolved function pointers for one (metric, DataType) combination.
+// Production scanner hot loops now use compile-time-dispatched kernel symbols,
+// but benchmarks and kernel-focused tests still need a runtime-selected view of
+// the available helpers.
+//
 // For DOT, both `dist` and `dot` are populated with the same kernel so callers
 // can use explicit dot-oriented names on the DOT execution path.
 // For L2, `dist` is always populated and `dot`/`squared_norm` may also be
-// populated so scanners can reuse persisted squared norms.
+// populated so callers can compare the raw path with the stored-norm helpers.
 // For COS all four fields are populated.
 struct ComputeKernels {
     ComputeDistFn              dist = nullptr;
@@ -45,7 +49,7 @@ struct ComputeKernels {
     ComputeDotFn               dot = nullptr;
 };
 
-// Resolves the kernel set for a given engine, metric, and data type.
+// Resolves the benchmark/test kernel set for a given engine, metric, and data type.
 ComputeKernels resolve_compute_kernels(ComputeEngine engine, DistFunc func, DataType type);
 
 } // namespace sketch2

--- a/src/core/compute/scanner_dataset_scan.h
+++ b/src/core/compute/scanner_dataset_scan.h
@@ -108,66 +108,51 @@ inline Ret scan_dataset_readers(uint64_t query_id, const std::vector<DataReaderP
     return Ret(0);
 }
 
+template <ComputeDistFn DistFn>
 inline Ret scan_dataset_heap_with_dist(uint64_t query_id, const DatasetReader& dataset, size_t count,
-        DistHeap* heap, ComputeDistFn dist_fn, const QueryDistContext& query, DistFunc func,
+        DistHeap* heap, const QueryDistContext& query, DistFunc func,
         const BitsetFilter* bitset = nullptr) {
     std::vector<DataReaderPtr> readers;
     CHECK(collect_dataset_readers(dataset, query_id, &readers));
     return scan_dataset_readers(
         query_id, readers, count, heap,
-        [dist_fn, query, query_id](const DataReader& reader, size_t local_count, DistHeap* local_heap,
+        [query_id, query](const DataReader& reader, size_t local_count, DistHeap* local_heap,
                 const BitsetFilter* bitset_filter) {
             log_reader_scan_plan(query_id, reader, "raw_dist", false, bitset_filter != nullptr);
-            scan_data_reader_with_dist(reader, local_count, local_heap, dist_fn, query, bitset_filter);
+            scan_data_reader_with_dist<DistFn>(reader, local_count, local_heap, query, bitset_filter);
         },
         func,
         bitset);
 }
 
+template <ComputeDotFn DotFn>
 inline Ret scan_dataset_heap_with_dot(uint64_t query_id, const DatasetReader& dataset, size_t count,
-        DistHeap* heap, ComputeDotFn dot_fn, const QueryDotContext& query, DistFunc func,
+        DistHeap* heap, const QueryDotContext& query, DistFunc func,
         const BitsetFilter* bitset = nullptr) {
     assert(func == DistFunc::DOT);
     std::vector<DataReaderPtr> readers;
     CHECK(collect_dataset_readers(dataset, query_id, &readers));
     return scan_dataset_readers(
         query_id, readers, count, heap,
-        [dot_fn, query, query_id](const DataReader& reader, size_t local_count, DistHeap* local_heap,
+        [query_id, query](const DataReader& reader, size_t local_count, DistHeap* local_heap,
                 const BitsetFilter* bitset_filter) {
             log_reader_scan_plan(query_id, reader, "dot", false, bitset_filter != nullptr);
-            scan_data_reader_with_dot(reader, local_count, local_heap, dot_fn, query, bitset_filter);
+            scan_data_reader_with_dot<DotFn>(reader, local_count, local_heap, query, bitset_filter);
         },
         func,
         bitset);
 }
 
-inline Ret scan_dataset_heap_with_query_norm(uint64_t query_id, const DatasetReader& dataset, size_t count,
-        DistHeap* heap, ComputeDistWithQueryNormFn dist_fn, const QueryCosContext& query,
-        DistFunc func, const BitsetFilter* bitset = nullptr) {
-    std::vector<DataReaderPtr> readers;
-    CHECK(collect_dataset_readers(dataset, query_id, &readers));
-    return scan_dataset_readers(
-        query_id, readers, count, heap,
-        [dist_fn, query, query_id](const DataReader& reader, size_t local_count,
-                DistHeap* local_heap, const BitsetFilter* bitset_filter) {
-            log_reader_scan_plan(query_id, reader, "cos_query_norm", false, bitset_filter != nullptr);
-            scan_data_reader_with_query_norm(
-                reader, local_count, local_heap, dist_fn, query, bitset_filter);
-        },
-        func,
-        bitset);
-}
-
+template <ComputeDotFn DotFn, ComputeDistWithQueryNormFn FallbackDistFn>
 inline Ret scan_dataset_heap_with_optional_cosine_norms(uint64_t query_id,
-        const DatasetReader& dataset, size_t count, DistHeap* heap, ComputeDotFn dot_fn,
-        ComputeDistWithQueryNormFn fallback_dist_fn, const QueryCosContext& query, DistFunc func,
-        const BitsetFilter* bitset = nullptr) {
+        const DatasetReader& dataset, size_t count, DistHeap* heap, const QueryCosContext& query,
+        DistFunc func, const BitsetFilter* bitset = nullptr) {
     assert(func == DistFunc::COS);
     std::vector<DataReaderPtr> readers;
     CHECK(collect_dataset_readers(dataset, query_id, &readers));
     return scan_dataset_readers(
         query_id, readers, count, heap,
-        [dot_fn, fallback_dist_fn, query, func, query_id](
+        [query, func, query_id](
                 const DataReader& reader, size_t local_count, DistHeap* local_heap,
                 const BitsetFilter* bitset_filter) {
             const bool uses_stored_norms = reader.has_matching_stored_norms(func);
@@ -175,27 +160,27 @@ inline Ret scan_dataset_heap_with_optional_cosine_norms(uint64_t query_id,
                 uses_stored_norms ? "cos_stored_norms" : "cos_query_norm_fallback",
                 uses_stored_norms, bitset_filter != nullptr);
             if (uses_stored_norms) {
-                scan_data_reader_with_cos_stored_norms(
-                    reader, local_count, local_heap, dot_fn, query, bitset_filter);
+                scan_data_reader_with_cos_stored_norms<DotFn>(
+                    reader, local_count, local_heap, query, bitset_filter);
             } else {
-                scan_data_reader_with_query_norm(
-                    reader, local_count, local_heap, fallback_dist_fn, query, bitset_filter);
+                scan_data_reader_with_query_norm<FallbackDistFn>(
+                    reader, local_count, local_heap, query, bitset_filter);
             }
         },
         func,
         bitset);
 }
 
+template <ComputeDotFn DotFn, ComputeDistFn FallbackDistFn>
 inline Ret scan_dataset_heap_with_optional_l2_norms(uint64_t query_id,
-        const DatasetReader& dataset, size_t count, DistHeap* heap, ComputeDotFn dot_fn,
-        ComputeDistFn fallback_dist_fn, const QueryL2Context& query, DistFunc func,
-        const BitsetFilter* bitset = nullptr) {
+        const DatasetReader& dataset, size_t count, DistHeap* heap, const QueryL2Context& query,
+        DistFunc func, const BitsetFilter* bitset = nullptr) {
     assert(func == DistFunc::L2);
     std::vector<DataReaderPtr> readers;
     CHECK(collect_dataset_readers(dataset, query_id, &readers));
     return scan_dataset_readers(
         query_id, readers, count, heap,
-        [dot_fn, fallback_dist_fn, query, func, query_id](
+        [query, func, query_id](
                 const DataReader& reader, size_t local_count, DistHeap* local_heap,
                 const BitsetFilter* bitset_filter) {
             const bool uses_stored_norms = reader.has_matching_stored_norms(func);
@@ -203,11 +188,11 @@ inline Ret scan_dataset_heap_with_optional_l2_norms(uint64_t query_id,
                 uses_stored_norms ? "l2_stored_norms" : "l2_dist_fallback",
                 uses_stored_norms, bitset_filter != nullptr);
             if (uses_stored_norms) {
-                scan_data_reader_with_l2_stored_norms(
-                    reader, local_count, local_heap, dot_fn, query, bitset_filter);
+                scan_data_reader_with_l2_stored_norms<DotFn>(
+                    reader, local_count, local_heap, query, bitset_filter);
             } else {
-                scan_data_reader_with_dist(
-                    reader, local_count, local_heap, fallback_dist_fn,
+                scan_data_reader_with_dist<FallbackDistFn>(
+                    reader, local_count, local_heap,
                     QueryDistContext{query.vec, query.dim}, bitset_filter);
             }
         },

--- a/src/core/compute/scanner_heap_utils.h
+++ b/src/core/compute/scanner_heap_utils.h
@@ -32,6 +32,51 @@ inline void push_result(DistHeap* heap, size_t count, uint64_t id, double score)
     }
 }
 
+inline void push_result_smaller_better(DistHeap* heap, size_t count, uint64_t id, double score) {
+    const DistItem item{id, score};
+    if (heap->size() < count) {
+        heap->push(item);
+        return;
+    }
+
+    const DistItem& top = heap->top();
+    if (score < top.score || (score == top.score && id < top.id)) {
+        heap->pop();
+        heap->push(item);
+    }
+}
+
+inline bool push_result_smaller_better_changed(DistHeap* heap, size_t count, uint64_t id, double score) {
+    const DistItem item{id, score};
+    if (heap->size() < count) {
+        heap->push(item);
+        return true;
+    }
+
+    const DistItem& top = heap->top();
+    if (score < top.score || (score == top.score && id < top.id)) {
+        heap->pop();
+        heap->push(item);
+        return true;
+    }
+
+    return false;
+}
+
+inline void push_result_larger_better(DistHeap* heap, size_t count, uint64_t id, double score) {
+    const DistItem item{id, score};
+    if (heap->size() < count) {
+        heap->push(item);
+        return;
+    }
+
+    const DistItem& top = heap->top();
+    if (score > top.score || (score == top.score && id < top.id)) {
+        heap->pop();
+        heap->push(item);
+    }
+}
+
 inline void extract_items(DistHeap* heap, std::vector<DistItem>* result) {
     result->resize(heap->size());
     for (size_t i = heap->size(); i-- > 0;) {

--- a/src/core/compute/scanner_hw.cpp
+++ b/src/core/compute/scanner_hw.cpp
@@ -473,6 +473,74 @@ double hwy_dist_cos_qn_i16(const uint8_t* a, const uint8_t* b, size_t dim, doubl
     return HWY_DYNAMIC_DISPATCH(DistCosWithQueryNormI16)(a, b, dim, qn);
 }
 
+Ret validate_hwy_kernel_support(DistFunc func, DataType type) {
+    try {
+        const ComputeKernels kernels = resolve_hwy_kernels(func, type);
+        if (kernels.dist == nullptr) {
+            return Ret(std::string("ScannerHw::find_items: missing dist kernel for ")
+                + dist_func_to_string(func) + "/" + data_type_to_string(type) + ".");
+        }
+        if ((func == DistFunc::L2 || func == DistFunc::COS)
+                && (kernels.dot == nullptr || kernels.squared_norm == nullptr)) {
+            return Ret(std::string("ScannerHw::find_items: missing stored-norm helpers for ")
+                + dist_func_to_string(func) + "/" + data_type_to_string(type) + ".");
+        }
+        if (func == DistFunc::COS && kernels.dist_with_query_norm == nullptr) {
+            return Ret(std::string("ScannerHw::find_items: missing query-norm kernel for ")
+                + dist_func_to_string(func) + "/" + data_type_to_string(type) + ".");
+        }
+        return Ret(0);
+    } catch (const std::exception& ex) {
+        return Ret(ex.what());
+    }
+}
+
+#define HWY_FOR_EACH_DOT_KERNEL(X) \
+    X(f32, hwy_dot_f32) \
+    X(f16, hwy_dot_f16) \
+    X(i16, hwy_dot_i16)
+
+#define HWY_FOR_EACH_L2_KERNEL(X) \
+    X(f32, hwy_dot_f32, hwy_dist_l2_f32, hwy_squared_norm_f32) \
+    X(f16, hwy_dot_f16, hwy_dist_l2_f16, hwy_squared_norm_f16) \
+    X(i16, hwy_dot_i16, hwy_dist_l2_i16, hwy_squared_norm_i16)
+
+#define HWY_FOR_EACH_COS_KERNEL(X) \
+    X(f32, hwy_dot_f32, hwy_dist_cos_f32, hwy_dist_cos_qn_f32, hwy_squared_norm_f32) \
+    X(f16, hwy_dot_f16, hwy_dist_cos_f16, hwy_dist_cos_qn_f16, hwy_squared_norm_f16) \
+    X(i16, hwy_dot_i16, hwy_dist_cos_i16, hwy_dist_cos_qn_i16, hwy_squared_norm_i16)
+
+#define HWY_DISPATCH_COS_CASE(TYPE_TAG, DOT_KERNEL, DIST_KERNEL, DIST_QN_KERNEL, SQ_NORM_KERNEL) \
+    case DataType::TYPE_TAG: { \
+        const double query_norm_sq = SQ_NORM_KERNEL(vec, dim); \
+        log_query_branch(query_id, "cos_with_optional_norms", \
+            query_norm_sq, query_norm_sq == 0.0); \
+        const QueryCosContext query{ \
+            vec, dim, query_norm_sq, query_inverse_norm(query_norm_sq)}; \
+        CHECK((scan_dataset_heap_with_optional_cosine_norms< \
+            DOT_KERNEL, DIST_QN_KERNEL>( \
+            query_id, dataset, count, &heap, query, func, bitset))); \
+        break; \
+    }
+
+#define HWY_DISPATCH_DOT_CASE(TYPE_TAG, DOT_KERNEL) \
+    case DataType::TYPE_TAG: \
+        CHECK(scan_dataset_heap_with_dot<DOT_KERNEL>( \
+            query_id, dataset, count, &heap, query, func, bitset)); \
+        break;
+
+#define HWY_DISPATCH_L2_CASE(TYPE_TAG, DOT_KERNEL, DIST_KERNEL, SQ_NORM_KERNEL) \
+    case DataType::TYPE_TAG: { \
+        const double query_norm_sq = SQ_NORM_KERNEL(vec, dim); \
+        log_query_branch(query_id, "l2_with_optional_norms", \
+            query_norm_sq, query_norm_sq == 0.0); \
+        const QueryL2Context query{vec, dim, query_norm_sq}; \
+        CHECK((scan_dataset_heap_with_optional_l2_norms< \
+            DOT_KERNEL, DIST_KERNEL>( \
+            query_id, dataset, count, &heap, query, func, bitset))); \
+        break; \
+    }
+
 Ret find_items_hw_impl(const DatasetReader& dataset, size_t count, const uint8_t* vec,
         std::vector<DistItem>* result, const BitsetFilter* bitset, uint64_t query_id) {
     if (vec == nullptr || count == 0 || result == nullptr) {
@@ -482,11 +550,12 @@ Ret find_items_hw_impl(const DatasetReader& dataset, size_t count, const uint8_t
     result->clear();
     const DistFunc func = dataset.dist_func();
     const size_t dim = dataset.dim();
-    const ComputeKernels kernels = resolve_hwy_kernels(func, dataset.type());
+    const DataType type = dataset.type();
+    CHECK(validate_hwy_kernel_support(func, type));
     if (query_id == 0) {
         query_id = next_scanner_query_id();
     }
-    log_query_start(query_id, dataset.name(), func, dataset.type(), dim, count,
+    log_query_start(query_id, dataset.name(), func, type, dim, count,
         ComputeEngine::highway, bitset != nullptr);
 
     DistHeap heap(DistItemCompare{func});
@@ -494,36 +563,31 @@ Ret find_items_hw_impl(const DatasetReader& dataset, size_t count, const uint8_t
     Timer timer("scanner_hw::query");
 
     if (func == DistFunc::COS) {
-        assert(kernels.squared_norm && kernels.dot && kernels.dist_with_query_norm);
-        const double query_norm_sq = kernels.squared_norm(vec, dim);
-        log_query_branch(query_id, "cos_with_optional_norms", query_norm_sq, query_norm_sq == 0.0);
-        const QueryCosContext query{vec, dim, query_norm_sq, query_inverse_norm(query_norm_sq)};
-        CHECK(scan_dataset_heap_with_optional_cosine_norms(
-            query_id, dataset, count, &heap, kernels.dot, kernels.dist_with_query_norm,
-            query, func, bitset));
+        switch (type) {
+            HWY_FOR_EACH_COS_KERNEL(HWY_DISPATCH_COS_CASE);
+            default:
+                return Ret("ScannerHw::find_items: unsupported DataType for COS.");
+        }
     } else if (func == DistFunc::DOT) {
-        assert(kernels.dot);
         log_query_branch(query_id, "dot");
         const QueryDotContext query{vec, dim};
-        CHECK(scan_dataset_heap_with_dot(
-            query_id, dataset, count, &heap, kernels.dot, query, func, bitset));
-    } else if (func == DistFunc::L2 && kernels.squared_norm && kernels.dot) {
-        assert(kernels.dist);
-        const double query_norm_sq = kernels.squared_norm(vec, dim);
-        log_query_branch(query_id, "l2_with_optional_norms", query_norm_sq, query_norm_sq == 0.0);
-        const QueryL2Context query{vec, dim, query_norm_sq};
-        CHECK(scan_dataset_heap_with_optional_l2_norms(
-            query_id, dataset, count, &heap, kernels.dot, kernels.dist, query, func, bitset));
+        switch (type) {
+            HWY_FOR_EACH_DOT_KERNEL(HWY_DISPATCH_DOT_CASE);
+            default:
+                return Ret("ScannerHw::find_items: unsupported DataType for DOT.");
+        }
+    } else if (func == DistFunc::L2) {
+        switch (type) {
+            HWY_FOR_EACH_L2_KERNEL(HWY_DISPATCH_L2_CASE);
+            default:
+                return Ret("ScannerHw::find_items: unsupported DataType for L2.");
+        }
     } else {
-        assert(kernels.dist);
-        log_query_branch(query_id, "raw_dist");
-        const QueryDistContext query{vec, dim};
-        CHECK(scan_dataset_heap_with_dist(
-            query_id, dataset, count, &heap, kernels.dist, query, func, bitset));
+        return Ret("ScannerHw::find_items: unsupported DistFunc.");
     }
 
     extract_items(&heap, result);
-    log_query_finish(query_id, dataset.name(), func, dataset.type(), dim, count,
+    log_query_finish(query_id, dataset.name(), func, type, dim, count,
         ComputeEngine::highway, timer.elapsed_ms(), *result);
     return Ret(0);
 }
@@ -540,54 +604,39 @@ ComputeKernels resolve_hwy_kernels(DistFunc func, DataType type) {
     switch (func) {
         case DistFunc::DOT:
             switch (type) {
-                case DataType::f32: k.dist = &hwy_dot_f32; k.dot = &hwy_dot_f32; break;
-                case DataType::f16: k.dist = &hwy_dot_f16; k.dot = &hwy_dot_f16; break;
-                case DataType::i16: k.dist = &hwy_dot_i16; k.dot = &hwy_dot_i16; break;
+#define HWY_RESOLVE_DOT_CASE(TYPE_TAG, DOT_KERNEL) \
+                case DataType::TYPE_TAG: k.dist = &DOT_KERNEL; k.dot = &DOT_KERNEL; break;
+                HWY_FOR_EACH_DOT_KERNEL(HWY_RESOLVE_DOT_CASE)
+#undef HWY_RESOLVE_DOT_CASE
                 default:
                     throw std::runtime_error("resolve_hwy_kernels: unsupported DataType for DOT.");
             }
             break;
         case DistFunc::L2:
             switch (type) {
-                case DataType::f32:
-                    k.dist = &hwy_dist_l2_f32;
-                    k.squared_norm = &hwy_squared_norm_f32;
-                    k.dot = &hwy_dot_f32;
+#define HWY_RESOLVE_L2_CASE(TYPE_TAG, DOT_KERNEL, DIST_KERNEL, SQ_NORM_KERNEL) \
+                case DataType::TYPE_TAG: \
+                    k.dist = &DIST_KERNEL; \
+                    k.squared_norm = &SQ_NORM_KERNEL; \
+                    k.dot = &DOT_KERNEL; \
                     break;
-                case DataType::f16:
-                    k.dist = &hwy_dist_l2_f16;
-                    k.squared_norm = &hwy_squared_norm_f16;
-                    k.dot = &hwy_dot_f16;
-                    break;
-                case DataType::i16:
-                    k.dist = &hwy_dist_l2_i16;
-                    k.squared_norm = &hwy_squared_norm_i16;
-                    k.dot = &hwy_dot_i16;
-                    break;
+                HWY_FOR_EACH_L2_KERNEL(HWY_RESOLVE_L2_CASE)
+#undef HWY_RESOLVE_L2_CASE
                 default:
                     throw std::runtime_error("resolve_hwy_kernels: unsupported DataType for L2.");
             }
             break;
         case DistFunc::COS:
             switch (type) {
-                case DataType::f32:
-                    k.dist = &hwy_dist_cos_f32;
-                    k.dist_with_query_norm = &hwy_dist_cos_qn_f32;
-                    k.squared_norm = &hwy_squared_norm_f32;
-                    k.dot = &hwy_dot_f32;
+#define HWY_RESOLVE_COS_CASE(TYPE_TAG, DOT_KERNEL, DIST_KERNEL, DIST_QN_KERNEL, SQ_NORM_KERNEL) \
+                case DataType::TYPE_TAG: \
+                    k.dist = &DIST_KERNEL; \
+                    k.dist_with_query_norm = &DIST_QN_KERNEL; \
+                    k.squared_norm = &SQ_NORM_KERNEL; \
+                    k.dot = &DOT_KERNEL; \
                     break;
-                case DataType::f16:
-                    k.dist = &hwy_dist_cos_f16;
-                    k.dist_with_query_norm = &hwy_dist_cos_qn_f16;
-                    k.squared_norm = &hwy_squared_norm_f16;
-                    k.dot = &hwy_dot_f16;
-                    break;
-                case DataType::i16:
-                    k.dist = &hwy_dist_cos_i16;
-                    k.dist_with_query_norm = &hwy_dist_cos_qn_i16;
-                    k.squared_norm = &hwy_squared_norm_i16;
-                    k.dot = &hwy_dot_i16;
-                    break;
+                HWY_FOR_EACH_COS_KERNEL(HWY_RESOLVE_COS_CASE)
+#undef HWY_RESOLVE_COS_CASE
                 default:
                     throw std::runtime_error("resolve_hwy_kernels: unsupported DataType for COS.");
             }
@@ -597,6 +646,13 @@ ComputeKernels resolve_hwy_kernels(DistFunc func, DataType type) {
     }
     return k;
 }
+
+#undef HWY_DISPATCH_COS_CASE
+#undef HWY_DISPATCH_DOT_CASE
+#undef HWY_DISPATCH_L2_CASE
+#undef HWY_FOR_EACH_DOT_KERNEL
+#undef HWY_FOR_EACH_L2_KERNEL
+#undef HWY_FOR_EACH_COS_KERNEL
 
 Ret ScannerHw::find(const DatasetReader& dataset, size_t count, const uint8_t* vec,
         std::vector<uint64_t>& result) const {

--- a/src/core/compute/scanner_hw.h
+++ b/src/core/compute/scanner_hw.h
@@ -25,6 +25,7 @@ public:
 Ret find_items_hw(const DatasetReader& dataset, size_t count, const uint8_t* vec,
     std::vector<DistItem>* result, const BitsetFilter* bitset = nullptr, uint64_t query_id = 0);
 
+// Runtime kernel resolver kept for benchmarks and kernel-focused tests.
 ComputeKernels resolve_hwy_kernels(DistFunc func, DataType type);
 
 } // namespace sketch2

--- a/src/core/compute/scanner_nk.cpp
+++ b/src/core/compute/scanner_nk.cpp
@@ -359,6 +359,71 @@ double nk_dist_cos_qn_f16(const uint8_t* a, const uint8_t* b, size_t dim, double
                                     query_norm_sq);
 }
 
+Ret validate_nk_kernel_support(DistFunc func, DataType type) {
+    try {
+        const ComputeKernels kernels = resolve_nk_kernels(func, type);
+        if (kernels.dist == nullptr) {
+            return Ret(std::string("ScannerNk::find_items: missing dist kernel for ")
+                + dist_func_to_string(func) + "/" + data_type_to_string(type) + ".");
+        }
+        if ((func == DistFunc::L2 || func == DistFunc::COS)
+                && (kernels.dot == nullptr || kernels.squared_norm == nullptr)) {
+            return Ret(std::string("ScannerNk::find_items: missing stored-norm helpers for ")
+                + dist_func_to_string(func) + "/" + data_type_to_string(type) + ".");
+        }
+        if (func == DistFunc::COS && kernels.dist_with_query_norm == nullptr) {
+            return Ret(std::string("ScannerNk::find_items: missing query-norm kernel for ")
+                + dist_func_to_string(func) + "/" + data_type_to_string(type) + ".");
+        }
+        return Ret(0);
+    } catch (const std::exception& ex) {
+        return Ret(ex.what());
+    }
+}
+
+#define NK_FOR_EACH_DOT_KERNEL(X) \
+    X(f32, nk_dot_product_f32) \
+    X(f16, nk_dot_product_f16)
+
+#define NK_FOR_EACH_L2_KERNEL(X) \
+    X(f32, nk_dot_product_f32, nk_dist_l2_f32, nk_squared_norm_f32) \
+    X(f16, nk_dot_product_f16, nk_dist_l2_f16, nk_squared_norm_f16)
+
+#define NK_FOR_EACH_COS_KERNEL(X) \
+    X(f32, nk_dot_product_f32, nk_dist_cos_f32, nk_dist_cos_qn_f32, nk_squared_norm_f32) \
+    X(f16, nk_dot_product_f16, nk_dist_cos_f16, nk_dist_cos_qn_f16, nk_squared_norm_f16)
+
+#define NK_DISPATCH_COS_CASE(TYPE_TAG, DOT_KERNEL, DIST_KERNEL, DIST_QN_KERNEL, SQ_NORM_KERNEL) \
+    case DataType::TYPE_TAG: { \
+        const double query_norm_sq = SQ_NORM_KERNEL(vec, dim); \
+        log_query_branch(query_id, "cos_with_optional_norms", \
+            query_norm_sq, query_norm_sq == 0.0); \
+        const QueryCosContext query{ \
+            vec, dim, query_norm_sq, query_inverse_norm(query_norm_sq)}; \
+        CHECK((scan_dataset_heap_with_optional_cosine_norms< \
+            DOT_KERNEL, DIST_QN_KERNEL>( \
+            query_id, dataset, count, &heap, query, func, bitset))); \
+        break; \
+    }
+
+#define NK_DISPATCH_DOT_CASE(TYPE_TAG, DOT_KERNEL) \
+    case DataType::TYPE_TAG: \
+        CHECK(scan_dataset_heap_with_dot<DOT_KERNEL>( \
+            query_id, dataset, count, &heap, query, func, bitset)); \
+        break;
+
+#define NK_DISPATCH_L2_CASE(TYPE_TAG, DOT_KERNEL, DIST_KERNEL, SQ_NORM_KERNEL) \
+    case DataType::TYPE_TAG: { \
+        const double query_norm_sq = SQ_NORM_KERNEL(vec, dim); \
+        log_query_branch(query_id, "l2_with_optional_norms", \
+            query_norm_sq, query_norm_sq == 0.0); \
+        const QueryL2Context query{vec, dim, query_norm_sq}; \
+        CHECK((scan_dataset_heap_with_optional_l2_norms< \
+            DOT_KERNEL, DIST_KERNEL>( \
+            query_id, dataset, count, &heap, query, func, bitset))); \
+        break; \
+    }
+
 Ret find_items_nk_impl(const DatasetReader& dataset, size_t count, const uint8_t* vec,
         std::vector<DistItem>* result, const BitsetFilter* bitset, uint64_t query_id) {
     if (vec == nullptr || count == 0 || result == nullptr) {
@@ -371,12 +436,13 @@ Ret find_items_nk_impl(const DatasetReader& dataset, size_t count, const uint8_t
     result->clear();
     const DistFunc func = dataset.dist_func();
     const size_t dim = dataset.dim();
-    const ComputeKernels kernels = resolve_nk_kernels(func, dataset.type());
+    const DataType type = dataset.type();
+    CHECK(validate_nk_kernel_support(func, type));
     if (query_id == 0) {
         query_id = next_scanner_query_id();
     }
-    log_query_start(query_id, dataset.name(), func, dataset.type(), dim, count,
-        ComputeEngine::numkong, bitset != nullptr, nk_compute_backend_name(func, dataset.type()),
+    log_query_start(query_id, dataset.name(), func, type, dim, count,
+        ComputeEngine::numkong, bitset != nullptr, nk_compute_backend_name(func, type),
         nk_compute_compiled_capabilities(), nk_compute_available_capabilities());
 
     DistHeap heap(DistItemCompare{func});
@@ -384,36 +450,31 @@ Ret find_items_nk_impl(const DatasetReader& dataset, size_t count, const uint8_t
     Timer timer("scanner_nk::query");
 
     if (func == DistFunc::COS) {
-        assert(kernels.squared_norm && kernels.dot && kernels.dist_with_query_norm);
-        const double query_norm_sq = kernels.squared_norm(vec, dim);
-        log_query_branch(query_id, "cos_with_optional_norms", query_norm_sq, query_norm_sq == 0.0);
-        const QueryCosContext query{vec, dim, query_norm_sq, query_inverse_norm(query_norm_sq)};
-        CHECK(scan_dataset_heap_with_optional_cosine_norms(
-            query_id, dataset, count, &heap, kernels.dot, kernels.dist_with_query_norm,
-            query, func, bitset));
+        switch (type) {
+            NK_FOR_EACH_COS_KERNEL(NK_DISPATCH_COS_CASE);
+            default:
+                return Ret("ScannerNk::find_items: unsupported DataType for COS.");
+        }
     } else if (func == DistFunc::DOT) {
-        assert(kernels.dot);
         log_query_branch(query_id, "dot");
         const QueryDotContext query{vec, dim};
-        CHECK(scan_dataset_heap_with_dot(
-            query_id, dataset, count, &heap, kernels.dot, query, func, bitset));
-    } else if (func == DistFunc::L2 && kernels.squared_norm && kernels.dot) {
-        assert(kernels.dist);
-        const double query_norm_sq = kernels.squared_norm(vec, dim);
-        log_query_branch(query_id, "l2_with_optional_norms", query_norm_sq, query_norm_sq == 0.0);
-        const QueryL2Context query{vec, dim, query_norm_sq};
-        CHECK(scan_dataset_heap_with_optional_l2_norms(
-            query_id, dataset, count, &heap, kernels.dot, kernels.dist, query, func, bitset));
+        switch (type) {
+            NK_FOR_EACH_DOT_KERNEL(NK_DISPATCH_DOT_CASE);
+            default:
+                return Ret("ScannerNk::find_items: unsupported DataType for DOT.");
+        }
+    } else if (func == DistFunc::L2) {
+        switch (type) {
+            NK_FOR_EACH_L2_KERNEL(NK_DISPATCH_L2_CASE);
+            default:
+                return Ret("ScannerNk::find_items: unsupported DataType for L2.");
+        }
     } else {
-        assert(kernels.dist);
-        log_query_branch(query_id, "raw_dist");
-        const QueryDistContext query{vec, dim};
-        CHECK(scan_dataset_heap_with_dist(
-            query_id, dataset, count, &heap, kernels.dist, query, func, bitset));
+        return Ret("ScannerNk::find_items: unsupported DistFunc.");
     }
 
     extract_items(&heap, result);
-    log_query_finish(query_id, dataset.name(), func, dataset.type(), dim, count,
+    log_query_finish(query_id, dataset.name(), func, type, dim, count,
         ComputeEngine::numkong, timer.elapsed_ms(), *result);
     return Ret(0);
 }
@@ -479,42 +540,39 @@ ComputeKernels resolve_nk_kernels(DistFunc func, DataType type) {
     switch (func) {
         case DistFunc::DOT:
             switch (type) {
-                case DataType::f32: k.dist = &nk_dot_product_f32; k.dot = &nk_dot_product_f32; break;
-                case DataType::f16: k.dist = &nk_dot_product_f16; k.dot = &nk_dot_product_f16; break;
+#define NK_RESOLVE_DOT_CASE(TYPE_TAG, DOT_KERNEL) \
+                case DataType::TYPE_TAG: k.dist = &DOT_KERNEL; k.dot = &DOT_KERNEL; break;
+                NK_FOR_EACH_DOT_KERNEL(NK_RESOLVE_DOT_CASE)
+#undef NK_RESOLVE_DOT_CASE
                 default:
                     throw std::runtime_error("resolve_nk_kernels: unsupported DataType for DOT.");
             }
             break;
         case DistFunc::L2:
             switch (type) {
-                case DataType::f32:
-                    k.dist = &nk_dist_l2_f32;
-                    k.squared_norm = &nk_squared_norm_f32;
-                    k.dot = &nk_dot_product_f32;
+#define NK_RESOLVE_L2_CASE(TYPE_TAG, DOT_KERNEL, DIST_KERNEL, SQ_NORM_KERNEL) \
+                case DataType::TYPE_TAG: \
+                    k.dist = &DIST_KERNEL; \
+                    k.squared_norm = &SQ_NORM_KERNEL; \
+                    k.dot = &DOT_KERNEL; \
                     break;
-                case DataType::f16:
-                    k.dist = &nk_dist_l2_f16;
-                    k.squared_norm = &nk_squared_norm_f16;
-                    k.dot = &nk_dot_product_f16;
-                    break;
+                NK_FOR_EACH_L2_KERNEL(NK_RESOLVE_L2_CASE)
+#undef NK_RESOLVE_L2_CASE
                 default:
                     throw std::runtime_error("resolve_nk_kernels: unsupported DataType for L2.");
             }
             break;
         case DistFunc::COS:
             switch (type) {
-                case DataType::f32:
-                    k.dist = &nk_dist_cos_f32;
-                    k.dist_with_query_norm = &nk_dist_cos_qn_f32;
-                    k.squared_norm = &nk_squared_norm_f32;
-                    k.dot = &nk_dot_product_f32;
+#define NK_RESOLVE_COS_CASE(TYPE_TAG, DOT_KERNEL, DIST_KERNEL, DIST_QN_KERNEL, SQ_NORM_KERNEL) \
+                case DataType::TYPE_TAG: \
+                    k.dist = &DIST_KERNEL; \
+                    k.dist_with_query_norm = &DIST_QN_KERNEL; \
+                    k.squared_norm = &SQ_NORM_KERNEL; \
+                    k.dot = &DOT_KERNEL; \
                     break;
-                case DataType::f16:
-                    k.dist = &nk_dist_cos_f16;
-                    k.dist_with_query_norm = &nk_dist_cos_qn_f16;
-                    k.squared_norm = &nk_squared_norm_f16;
-                    k.dot = &nk_dot_product_f16;
-                    break;
+                NK_FOR_EACH_COS_KERNEL(NK_RESOLVE_COS_CASE)
+#undef NK_RESOLVE_COS_CASE
                 default:
                     throw std::runtime_error("resolve_nk_kernels: unsupported DataType for COS.");
             }
@@ -524,6 +582,13 @@ ComputeKernels resolve_nk_kernels(DistFunc func, DataType type) {
     }
     return k;
 }
+
+#undef NK_DISPATCH_COS_CASE
+#undef NK_DISPATCH_DOT_CASE
+#undef NK_DISPATCH_L2_CASE
+#undef NK_FOR_EACH_DOT_KERNEL
+#undef NK_FOR_EACH_L2_KERNEL
+#undef NK_FOR_EACH_COS_KERNEL
 
 Ret ScannerNk::find(const DatasetReader& dataset, size_t count, const uint8_t* vec,
         std::vector<uint64_t>& result) const {

--- a/src/core/compute/scanner_nk.h
+++ b/src/core/compute/scanner_nk.h
@@ -25,6 +25,7 @@ public:
 Ret find_items_nk(const DatasetReader& dataset, size_t count, const uint8_t* vec,
     std::vector<DistItem>* result, const BitsetFilter* bitset = nullptr, uint64_t query_id = 0);
 
+// Runtime kernel resolver kept for benchmarks and kernel-focused tests.
 ComputeKernels resolve_nk_kernels(DistFunc func, DataType type);
 bool nk_compute_uses_dynamic_dispatch();
 uint64_t nk_compute_compiled_capabilities();

--- a/src/core/compute/scanner_scan_loops.h
+++ b/src/core/compute/scanner_scan_loops.h
@@ -16,12 +16,12 @@ namespace sketch2 {
 constexpr size_t kPrefetchCacheLineBytes = 64;
 constexpr size_t kPrefetchDistance = 1;
 
-inline void prefetch_vector_record(const uint8_t* data, size_t vector_size_bytes) {
+inline void prefetch_vector_record(const uint8_t* data, size_t record_stride_bytes) {
     if (data == nullptr) {
         return;
     }
 
-    for (size_t offset = 0; offset < vector_size_bytes; offset += kPrefetchCacheLineBytes) {
+    for (size_t offset = 0; offset < record_stride_bytes; offset += kPrefetchCacheLineBytes) {
         __builtin_prefetch(data + offset, 0, 1);
     }
 }
@@ -44,14 +44,14 @@ inline bool bitset_contains_id(const BitsetFilter* bitset, uint64_t id) {
 }
 
 template <bool HasBitset, typename PushFn>
-inline void scan_ordered_iterator(DataReader::OrderedIterator it, size_t vector_size_bytes,
+inline void scan_ordered_iterator(DataReader::OrderedIterator it, size_t record_stride_bytes,
         const BitsetFilter* bitset, const PushFn& push_fn) {
     while (!it.eof()) {
         const uint64_t id = it.id();
         DataReader::OrderedIterator next_it = it;
         next_it.next();
         if (!next_it.eof()) {
-            prefetch_vector_record(next_it.data(), vector_size_bytes);
+            prefetch_vector_record(next_it.data(), record_stride_bytes);
         }
         if constexpr (HasBitset) {
             if (!bitset_contains_id(bitset, id)) {
@@ -65,29 +65,29 @@ inline void scan_ordered_iterator(DataReader::OrderedIterator it, size_t vector_
 }
 
 template <bool HasBitset, typename PushFn>
-inline void scan_data_reader(const DataReader& reader, size_t vector_size_bytes,
+inline void scan_data_reader(const DataReader& reader, size_t record_stride_bytes,
         const BitsetFilter* bitset, const PushFn& push_fn) {
     scan_ordered_iterator<HasBitset>(
-        reader.base_begin(), vector_size_bytes, bitset, push_fn);
+        reader.base_begin(), record_stride_bytes, bitset, push_fn);
     scan_ordered_iterator<HasBitset>(
-        reader.delta_begin(), vector_size_bytes, bitset, push_fn);
+        reader.delta_begin(), record_stride_bytes, bitset, push_fn);
 }
 
 template <typename PushFn>
 inline void scan_data_reader_with_optional_bitset(const DataReader& reader,
-        size_t vector_size_bytes, const BitsetFilter* bitset, const PushFn& push_fn) {
+        size_t record_stride_bytes, const BitsetFilter* bitset, const PushFn& push_fn) {
     if (bitset == nullptr) {
-        scan_data_reader<false>(reader, vector_size_bytes, nullptr, push_fn);
+        scan_data_reader<false>(reader, record_stride_bytes, nullptr, push_fn);
         return;
     }
 
-    scan_data_reader<true>(reader, vector_size_bytes, bitset, push_fn);
+    scan_data_reader<true>(reader, record_stride_bytes, bitset, push_fn);
 }
 
 inline void scan_data_reader_with_dist(const DataReader& reader, size_t count, DistHeap* heap,
         ComputeDistFn dist_fn, const QueryDistContext& query, const BitsetFilter* bitset = nullptr) {
-    const size_t vector_size_bytes = reader.size();
-    scan_data_reader_with_optional_bitset(reader, vector_size_bytes, bitset,
+    const size_t record_stride_bytes = reader.stride();
+    scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
         [heap, count, dist_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
             push_result(heap, count, id, dist_fn(curr_it.data(), query.vec, query.dim));
         });
@@ -95,8 +95,8 @@ inline void scan_data_reader_with_dist(const DataReader& reader, size_t count, D
 
 inline void scan_data_reader_with_dot(const DataReader& reader, size_t count, DistHeap* heap,
         ComputeDotFn dot_fn, const QueryDotContext& query, const BitsetFilter* bitset = nullptr) {
-    const size_t vector_size_bytes = reader.size();
-    scan_data_reader_with_optional_bitset(reader, vector_size_bytes, bitset,
+    const size_t record_stride_bytes = reader.stride();
+    scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
         [heap, count, dot_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
             push_result(heap, count, id, dot_fn(curr_it.data(), query.vec, query.dim));
         });
@@ -105,8 +105,8 @@ inline void scan_data_reader_with_dot(const DataReader& reader, size_t count, Di
 inline void scan_data_reader_with_query_norm(const DataReader& reader, size_t count, DistHeap* heap,
         ComputeDistWithQueryNormFn dist_fn, const QueryCosContext& query,
         const BitsetFilter* bitset = nullptr) {
-    const size_t vector_size_bytes = reader.size();
-    scan_data_reader_with_optional_bitset(reader, vector_size_bytes, bitset,
+    const size_t record_stride_bytes = reader.stride();
+    scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
         [heap, count, dist_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
             push_result(heap, count, id,
                 dist_fn(curr_it.data(), query.vec, query.dim, query.norm_sq));
@@ -116,8 +116,8 @@ inline void scan_data_reader_with_query_norm(const DataReader& reader, size_t co
 inline void scan_data_reader_with_cos_stored_norms(const DataReader& reader, size_t count,
         DistHeap* heap, ComputeDotFn dot_fn, const QueryCosContext& query,
         const BitsetFilter* bitset = nullptr) {
-    const size_t vector_size_bytes = reader.size();
-    scan_data_reader_with_optional_bitset(reader, vector_size_bytes, bitset,
+    const size_t record_stride_bytes = reader.stride();
+    scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
         [heap, count, dot_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
             const double dot = dot_fn(curr_it.data(), query.vec, query.dim);
             push_result(heap, count, id, finalize_cosine_distance_from_inverse_norms(
@@ -128,8 +128,8 @@ inline void scan_data_reader_with_cos_stored_norms(const DataReader& reader, siz
 inline void scan_data_reader_with_l2_stored_norms(const DataReader& reader, size_t count,
         DistHeap* heap, ComputeDotFn dot_fn, const QueryL2Context& query,
         const BitsetFilter* bitset = nullptr) {
-    const size_t vector_size_bytes = reader.size();
-    scan_data_reader_with_optional_bitset(reader, vector_size_bytes, bitset,
+    const size_t record_stride_bytes = reader.stride();
+    scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
         [heap, count, dot_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
             const double dot = dot_fn(curr_it.data(), query.vec, query.dim);
             push_result(heap, count, id, finalize_squared_l2_distance_from_squared_norms(

--- a/src/core/compute/scanner_scan_loops.h
+++ b/src/core/compute/scanner_scan_loops.h
@@ -156,9 +156,15 @@ inline void scan_data_reader_with_cos_stored_norms(const DataReader& reader, siz
     const size_t norm_offset_in_record = reader.norm_offset_in_record_unchecked();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
         [heap, count, dot_fn, query, norm_offset_in_record](uint64_t id, const uint8_t* record) {
-            const double dot = dot_fn(record, query.vec, query.dim);
             float norm = 0.0f;
             std::memcpy(&norm, record + norm_offset_in_record, sizeof(norm));
+            if (norm == 0.0f) {
+                push_result_smaller_better(
+                    heap, count, id, query.inv_norm == 0.0 ? 0.0 : 1.0);
+                return;
+            }
+
+            const double dot = dot_fn(record, query.vec, query.dim);
             push_result_smaller_better(heap, count, id, finalize_cosine_distance_from_inverse_norms(
                 dot, static_cast<double>(norm), query.inv_norm));
         });

--- a/src/core/compute/scanner_scan_loops.h
+++ b/src/core/compute/scanner_scan_loops.h
@@ -43,33 +43,70 @@ inline bool bitset_contains_id(const BitsetFilter* bitset, uint64_t id) {
 }
 
 template <bool HasBitset, typename PushFn>
-inline void scan_ordered_iterator(DataReader::OrderedIterator it, size_t record_stride_bytes,
-        const BitsetFilter* bitset, const PushFn& push_fn) {
-    while (!it.eof()) {
-        const uint64_t id = it.id();
-        DataReader::OrderedIterator next_it = it;
-        next_it.next();
-        if (!next_it.eof()) {
-            prefetch_vector_record(next_it.data(), record_stride_bytes);
+inline void scan_reader_records(const DataReader& reader, size_t start_index, size_t end_index,
+        size_t record_stride_bytes, const BitsetFilter* bitset, const PushFn& push_fn) {
+    size_t index = start_index;
+    while (index < end_index) {
+        const uint64_t id = reader.id_unchecked(index);
+        const size_t next_index = index + 1;
+        if (next_index < end_index) {
+            prefetch_vector_record(reader.record_unchecked(next_index), record_stride_bytes);
         }
         if constexpr (HasBitset) {
             if (!bitset_contains_id(bitset, id)) {
-                it = next_it;
+                index = next_index;
                 continue;
             }
         }
-        push_fn(id, it);
-        it = next_it;
+        push_fn(id, reader.record_unchecked(index));
+        index = next_index;
+    }
+}
+
+template <bool HasBitset, typename PushFn>
+inline void scan_visible_base_records(const DataReader& reader, size_t record_stride_bytes,
+        const BitsetFilter* bitset, const PushFn& push_fn) {
+    const size_t end_index = reader.count_unchecked();
+    if (end_index == 0) {
+        return;
+    }
+
+    if (!reader.has_hidden_rows_unchecked()) {
+        scan_reader_records<HasBitset>(reader, 0, end_index, record_stride_bytes, bitset, push_fn);
+        return;
+    }
+
+    size_t index = reader.first_visible_base_index_unchecked();
+    while (index < end_index) {
+        const uint64_t id = reader.id_unchecked(index);
+        const size_t next_index = reader.next_visible_base_index_unchecked(index + 1);
+        if (next_index < end_index) {
+            prefetch_vector_record(reader.record_unchecked(next_index), record_stride_bytes);
+        }
+        if constexpr (HasBitset) {
+            if (!bitset_contains_id(bitset, id)) {
+                index = next_index;
+                continue;
+            }
+        }
+        push_fn(id, reader.record_unchecked(index));
+        index = next_index;
     }
 }
 
 template <bool HasBitset, typename PushFn>
 inline void scan_data_reader(const DataReader& reader, size_t record_stride_bytes,
         const BitsetFilter* bitset, const PushFn& push_fn) {
-    scan_ordered_iterator<HasBitset>(
-        reader.base_begin(), record_stride_bytes, bitset, push_fn);
-    scan_ordered_iterator<HasBitset>(
-        reader.delta_begin(), record_stride_bytes, bitset, push_fn);
+    scan_visible_base_records<HasBitset>(
+        reader, record_stride_bytes, bitset, push_fn);
+
+    const DataReader* delta_reader = reader.delta_reader_unchecked();
+    if (delta_reader == nullptr) {
+        return;
+    }
+
+    scan_reader_records<HasBitset>(
+        *delta_reader, 0, delta_reader->count_unchecked(), record_stride_bytes, bitset, push_fn);
 }
 
 template <typename PushFn>
@@ -87,8 +124,8 @@ inline void scan_data_reader_with_dist(const DataReader& reader, size_t count, D
         ComputeDistFn dist_fn, const QueryDistContext& query, const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dist_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
-            push_result(heap, count, id, dist_fn(curr_it.data(), query.vec, query.dim));
+        [heap, count, dist_fn, query](uint64_t id, const uint8_t* record) {
+            push_result_smaller_better(heap, count, id, dist_fn(record, query.vec, query.dim));
         });
 }
 
@@ -96,8 +133,8 @@ inline void scan_data_reader_with_dot(const DataReader& reader, size_t count, Di
         ComputeDotFn dot_fn, const QueryDotContext& query, const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dot_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
-            push_result(heap, count, id, dot_fn(curr_it.data(), query.vec, query.dim));
+        [heap, count, dot_fn, query](uint64_t id, const uint8_t* record) {
+            push_result_larger_better(heap, count, id, dot_fn(record, query.vec, query.dim));
         });
 }
 
@@ -106,9 +143,9 @@ inline void scan_data_reader_with_query_norm(const DataReader& reader, size_t co
         const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dist_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
-            push_result(heap, count, id,
-                dist_fn(curr_it.data(), query.vec, query.dim, query.norm_sq));
+        [heap, count, dist_fn, query](uint64_t id, const uint8_t* record) {
+            push_result_smaller_better(heap, count, id,
+                dist_fn(record, query.vec, query.dim, query.norm_sq));
         });
 }
 
@@ -116,25 +153,105 @@ inline void scan_data_reader_with_cos_stored_norms(const DataReader& reader, siz
         DistHeap* heap, ComputeDotFn dot_fn, const QueryCosContext& query,
         const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
+    const size_t norm_offset_in_record = reader.norm_offset_in_record_unchecked();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dot_fn, query, &reader](uint64_t id, DataReader::OrderedIterator curr_it) {
-            const uint8_t* record = curr_it.data();
+        [heap, count, dot_fn, query, norm_offset_in_record](uint64_t id, const uint8_t* record) {
             const double dot = dot_fn(record, query.vec, query.dim);
-            push_result(heap, count, id, finalize_cosine_distance_from_inverse_norms(
-                dot, static_cast<double>(reader.get_norm_from_record_unchecked(record)), query.inv_norm));
+            float norm = 0.0f;
+            std::memcpy(&norm, record + norm_offset_in_record, sizeof(norm));
+            push_result_smaller_better(heap, count, id, finalize_cosine_distance_from_inverse_norms(
+                dot, static_cast<double>(norm), query.inv_norm));
         });
+}
+
+struct L2StoredNormLowerBoundState {
+    double query_norm = 0.0;
+    double lo_stored_norm_sq = 0.0;
+    double hi_stored_norm_sq = 0.0;
+    bool heap_is_full = false;
+    bool thresholds_valid = false;
+};
+
+inline void refresh_l2_stored_norm_lower_bound(const DistHeap& heap, size_t count,
+        L2StoredNormLowerBoundState* state) {
+    if (state->thresholds_valid) {
+        return;
+    }
+
+    if (!state->heap_is_full) {
+        if (heap.size() < count) {
+            return;
+        }
+        state->heap_is_full = true;
+    }
+
+    const double heap_worst_score = std::max(0.0, heap.top().score);
+    const double sqrt_heap_worst_score = std::sqrt(heap_worst_score);
+    const double lo_stored_norm = std::max(0.0, state->query_norm - sqrt_heap_worst_score);
+    const double hi_stored_norm = state->query_norm + sqrt_heap_worst_score;
+    state->lo_stored_norm_sq = lo_stored_norm * lo_stored_norm;
+    state->hi_stored_norm_sq = hi_stored_norm * hi_stored_norm;
+    state->thresholds_valid = true;
+}
+
+inline void update_l2_stored_norm_lower_bound_after_push(const DistHeap& heap, size_t count,
+        bool heap_changed, L2StoredNormLowerBoundState* state) {
+    if (!state->heap_is_full) {
+        if (heap.size() < count) {
+            return;
+        }
+        state->heap_is_full = true;
+        state->thresholds_valid = false;
+        return;
+    }
+
+    if (heap_changed) {
+        state->thresholds_valid = false;
+    }
+}
+
+inline bool l2_stored_norm_lower_bound_exceeds_heap(const DistHeap& heap, size_t count,
+        double stored_norm_sq, L2StoredNormLowerBoundState* state) {
+    refresh_l2_stored_norm_lower_bound(heap, count, state);
+    if (!state->thresholds_valid) {
+        return false;
+    }
+
+    const double clamped_stored_norm_sq = std::max(0.0, stored_norm_sq);
+
+    // Keep ties exact: an equal score can still win on smaller id, so only reject
+    // when the lower bound is strictly worse than the current heap worst score.
+    return clamped_stored_norm_sq < state->lo_stored_norm_sq
+        || clamped_stored_norm_sq > state->hi_stored_norm_sq;
 }
 
 inline void scan_data_reader_with_l2_stored_norms(const DataReader& reader, size_t count,
         DistHeap* heap, ComputeDotFn dot_fn, const QueryL2Context& query,
         const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
+    const size_t norm_offset_in_record = reader.norm_offset_in_record_unchecked();
+    L2StoredNormLowerBoundState lower_bound_state;
+    lower_bound_state.query_norm = std::sqrt(std::max(0.0, query.norm_sq));
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dot_fn, query, &reader](uint64_t id, DataReader::OrderedIterator curr_it) {
-            const uint8_t* record = curr_it.data();
+        [heap, count, dot_fn, query, norm_offset_in_record, lower_bound_state_ptr = &lower_bound_state](
+                uint64_t id, const uint8_t* record) {
+            float stored_norm_sq_f32 = 0.0f;
+            std::memcpy(&stored_norm_sq_f32, record + norm_offset_in_record, sizeof(stored_norm_sq_f32));
+            const double stored_norm_sq = static_cast<double>(stored_norm_sq_f32);
+
+            // Read the inline squared norm first so the cheap lower bound can skip
+            // the expensive dot kernel for candidates that cannot beat the full heap.
+            if (l2_stored_norm_lower_bound_exceeds_heap(
+                    *heap, count, stored_norm_sq, lower_bound_state_ptr)) {
+                return;
+            }
+
             const double dot = dot_fn(record, query.vec, query.dim);
-            push_result(heap, count, id, finalize_squared_l2_distance_from_squared_norms(
-                dot, static_cast<double>(reader.get_norm_from_record_unchecked(record)), query.norm_sq));
+            const bool heap_changed = push_result_smaller_better_changed(
+                heap, count, id, finalize_squared_l2_distance_from_squared_norms(
+                    dot, stored_norm_sq, query.norm_sq));
+            update_l2_stored_norm_lower_bound_after_push(
+                *heap, count, heap_changed, lower_bound_state_ptr);
         });
 }
 

--- a/src/core/compute/scanner_scan_loops.h
+++ b/src/core/compute/scanner_scan_loops.h
@@ -14,7 +14,6 @@
 namespace sketch2 {
 
 constexpr size_t kPrefetchCacheLineBytes = 64;
-constexpr size_t kPrefetchDistance = 1;
 
 inline void prefetch_vector_record(const uint8_t* data, size_t record_stride_bytes) {
     if (data == nullptr) {

--- a/src/core/compute/scanner_scan_loops.h
+++ b/src/core/compute/scanner_scan_loops.h
@@ -117,10 +117,11 @@ inline void scan_data_reader_with_cos_stored_norms(const DataReader& reader, siz
         const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dot_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
-            const double dot = dot_fn(curr_it.data(), query.vec, query.dim);
+        [heap, count, dot_fn, query, &reader](uint64_t id, DataReader::OrderedIterator curr_it) {
+            const uint8_t* record = curr_it.data();
+            const double dot = dot_fn(record, query.vec, query.dim);
             push_result(heap, count, id, finalize_cosine_distance_from_inverse_norms(
-                dot, static_cast<double>(curr_it.get_norm()), query.inv_norm));
+                dot, static_cast<double>(reader.get_norm_from_record_unchecked(record)), query.inv_norm));
         });
 }
 
@@ -129,10 +130,11 @@ inline void scan_data_reader_with_l2_stored_norms(const DataReader& reader, size
         const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dot_fn, query](uint64_t id, DataReader::OrderedIterator curr_it) {
-            const double dot = dot_fn(curr_it.data(), query.vec, query.dim);
+        [heap, count, dot_fn, query, &reader](uint64_t id, DataReader::OrderedIterator curr_it) {
+            const uint8_t* record = curr_it.data();
+            const double dot = dot_fn(record, query.vec, query.dim);
             push_result(heap, count, id, finalize_squared_l2_distance_from_squared_norms(
-                dot, static_cast<double>(curr_it.get_norm()), query.norm_sq));
+                dot, static_cast<double>(reader.get_norm_from_record_unchecked(record)), query.norm_sq));
         });
 }
 

--- a/src/core/compute/scanner_scan_loops.h
+++ b/src/core/compute/scanner_scan_loops.h
@@ -120,42 +120,44 @@ inline void scan_data_reader_with_optional_bitset(const DataReader& reader,
     scan_data_reader<true>(reader, record_stride_bytes, bitset, push_fn);
 }
 
+template <ComputeDistFn DistFn>
 inline void scan_data_reader_with_dist(const DataReader& reader, size_t count, DistHeap* heap,
-        ComputeDistFn dist_fn, const QueryDistContext& query, const BitsetFilter* bitset = nullptr) {
+        const QueryDistContext& query, const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dist_fn, query](uint64_t id, const uint8_t* record) {
-            push_result_smaller_better(heap, count, id, dist_fn(record, query.vec, query.dim));
+        [heap, count, query](uint64_t id, const uint8_t* record) {
+            push_result_smaller_better(heap, count, id, DistFn(record, query.vec, query.dim));
         });
 }
 
+template <ComputeDotFn DotFn>
 inline void scan_data_reader_with_dot(const DataReader& reader, size_t count, DistHeap* heap,
-        ComputeDotFn dot_fn, const QueryDotContext& query, const BitsetFilter* bitset = nullptr) {
+        const QueryDotContext& query, const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dot_fn, query](uint64_t id, const uint8_t* record) {
-            push_result_larger_better(heap, count, id, dot_fn(record, query.vec, query.dim));
+        [heap, count, query](uint64_t id, const uint8_t* record) {
+            push_result_larger_better(heap, count, id, DotFn(record, query.vec, query.dim));
         });
 }
 
+template <ComputeDistWithQueryNormFn DistFn>
 inline void scan_data_reader_with_query_norm(const DataReader& reader, size_t count, DistHeap* heap,
-        ComputeDistWithQueryNormFn dist_fn, const QueryCosContext& query,
-        const BitsetFilter* bitset = nullptr) {
+        const QueryCosContext& query, const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dist_fn, query](uint64_t id, const uint8_t* record) {
+        [heap, count, query](uint64_t id, const uint8_t* record) {
             push_result_smaller_better(heap, count, id,
-                dist_fn(record, query.vec, query.dim, query.norm_sq));
+                DistFn(record, query.vec, query.dim, query.norm_sq));
         });
 }
 
+template <ComputeDotFn DotFn>
 inline void scan_data_reader_with_cos_stored_norms(const DataReader& reader, size_t count,
-        DistHeap* heap, ComputeDotFn dot_fn, const QueryCosContext& query,
-        const BitsetFilter* bitset = nullptr) {
+        DistHeap* heap, const QueryCosContext& query, const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     const size_t norm_offset_in_record = reader.norm_offset_in_record_unchecked();
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dot_fn, query, norm_offset_in_record](uint64_t id, const uint8_t* record) {
+        [heap, count, query, norm_offset_in_record](uint64_t id, const uint8_t* record) {
             float norm = 0.0f;
             std::memcpy(&norm, record + norm_offset_in_record, sizeof(norm));
             if (norm == 0.0f) {
@@ -164,7 +166,7 @@ inline void scan_data_reader_with_cos_stored_norms(const DataReader& reader, siz
                 return;
             }
 
-            const double dot = dot_fn(record, query.vec, query.dim);
+            const double dot = DotFn(record, query.vec, query.dim);
             push_result_smaller_better(heap, count, id, finalize_cosine_distance_from_inverse_norms(
                 dot, static_cast<double>(norm), query.inv_norm));
         });
@@ -231,15 +233,15 @@ inline bool l2_stored_norm_lower_bound_exceeds_heap(const DistHeap& heap, size_t
         || clamped_stored_norm_sq > state->hi_stored_norm_sq;
 }
 
+template <ComputeDotFn DotFn>
 inline void scan_data_reader_with_l2_stored_norms(const DataReader& reader, size_t count,
-        DistHeap* heap, ComputeDotFn dot_fn, const QueryL2Context& query,
-        const BitsetFilter* bitset = nullptr) {
+        DistHeap* heap, const QueryL2Context& query, const BitsetFilter* bitset = nullptr) {
     const size_t record_stride_bytes = reader.stride();
     const size_t norm_offset_in_record = reader.norm_offset_in_record_unchecked();
     L2StoredNormLowerBoundState lower_bound_state;
     lower_bound_state.query_norm = std::sqrt(std::max(0.0, query.norm_sq));
     scan_data_reader_with_optional_bitset(reader, record_stride_bytes, bitset,
-        [heap, count, dot_fn, query, norm_offset_in_record, lower_bound_state_ptr = &lower_bound_state](
+        [heap, count, query, norm_offset_in_record, lower_bound_state_ptr = &lower_bound_state](
                 uint64_t id, const uint8_t* record) {
             float stored_norm_sq_f32 = 0.0f;
             std::memcpy(&stored_norm_sq_f32, record + norm_offset_in_record, sizeof(stored_norm_sq_f32));
@@ -252,7 +254,7 @@ inline void scan_data_reader_with_l2_stored_norms(const DataReader& reader, size
                 return;
             }
 
-            const double dot = dot_fn(record, query.vec, query.dim);
+            const double dot = DotFn(record, query.vec, query.dim);
             const bool heap_changed = push_result_smaller_better_changed(
                 heap, count, id, finalize_squared_l2_distance_from_squared_norms(
                     dot, stored_norm_sq, query.norm_sq));

--- a/src/core/compute/utest_scanner_ex.cpp
+++ b/src/core/compute/utest_scanner_ex.cpp
@@ -177,10 +177,12 @@ protected:
         ASSERT_LT(index, static_cast<size_t>(hdr.count));
         const DataRecordLayout record_layout = compute_data_record_layout(
             data_type_from_int(static_cast<int>(hdr.type)), hdr.dim, true);
+        ASSERT_GE(static_cast<size_t>(hdr.vector_stride), record_layout.norm_offset + sizeof(value));
 
+        const size_t record_offset =
+            static_cast<size_t>(hdr.data_offset) + index * static_cast<size_t>(hdr.vector_stride);
         const off_t norm_offset =
-            static_cast<off_t>(
-                hdr.data_offset + index * static_cast<size_t>(hdr.vector_stride) + record_layout.norm_offset);
+            static_cast<off_t>(record_offset + record_layout.norm_offset);
         ASSERT_EQ(static_cast<ssize_t>(sizeof(value)),
                   pwrite(fd, &value, sizeof(value), norm_offset));
         ASSERT_EQ(0, close(fd));

--- a/src/core/compute/utest_scanner_ex.cpp
+++ b/src/core/compute/utest_scanner_ex.cpp
@@ -12,6 +12,8 @@
 #include <filesystem>
 #include <experimental/scope>
 #include "core/compute/scanner.h"
+#include "core/compute/scanner_query_context.h"
+#include "core/compute/scanner_scan_loops.h"
 #include "core/utils/singleton.h"
 #include "core/utils/thread_pool.h"
 #include "core/storage/input_generator.h"
@@ -26,9 +28,21 @@ namespace fs = std::filesystem;
 namespace {
 
 constexpr ComputeEngine kCompiledComputeEngine = compiled_compute_engine();
+size_t g_counting_dot_calls = 0;
 
 Scanner make_compiled_scanner() {
     return Scanner(kCompiledComputeEngine);
+}
+
+double counting_f32_dot(const uint8_t* a, const uint8_t* b, size_t dim) {
+    ++g_counting_dot_calls;
+    const auto* aa = reinterpret_cast<const float*>(a);
+    const auto* bb = reinterpret_cast<const float*>(b);
+    double dot = 0.0;
+    for (size_t i = 0; i < dim; ++i) {
+        dot += static_cast<double>(aa[i]) * static_cast<double>(bb[i]);
+    }
+    return dot;
 }
 
 }
@@ -746,6 +760,80 @@ TEST_F(ScannerTest, FindDatasetL2UsesStoredSquaredNormsForHighwayAndNumKong) {
     EXPECT_NEAR(2.0, result[0].score, 1e-6) << "engine=" << compute_engine_name(kCompiledComputeEngine);
     EXPECT_EQ(10u, result[1].id) << "engine=" << compute_engine_name(kCompiledComputeEngine);
     EXPECT_NEAR(99.0, result[1].score, 1e-6) << "engine=" << compute_engine_name(kCompiledComputeEngine);
+}
+
+TEST_F(ScannerTest, L2StoredNormScanSkipsDotWhenNormLowerBoundCannotBeatHeap) {
+    write_input_raw(
+        input_path_,
+        "f32,4\n"
+        "10 : [ 1.0, 0.0, 0.0, 0.0 ]\n"
+        "20 : [ 10.0, 0.0, 0.0, 0.0 ]\n");
+
+    const std::string dataset_dir = data_path_ + ".dataset_" + std::to_string(cleanup_dirs_.size());
+    cleanup_dirs_.push_back(dataset_dir);
+    fs::create_directories(dataset_dir);
+
+    DatasetNode ds;
+    ASSERT_EQ(0, ds.init_for_test({dataset_dir}, 100, DataType::f32, 4, DistFunc::L2).code());
+    ASSERT_EQ(0, ds.store(input_path_).code());
+
+    DataReader reader;
+    ASSERT_EQ(0, reader.init(dataset_dir + "/0.data").code());
+
+    const auto q = f32_values({1.0f, 0.0f, 0.0f, 0.0f});
+    const QueryL2Context query{q.data(), 4, 1.0};
+    DistHeap heap(DistItemCompare{DistFunc::L2});
+    heap.reserve(1);
+
+    g_counting_dot_calls = 0;
+    scan_data_reader_with_l2_stored_norms(reader, 1, &heap, counting_f32_dot, query);
+
+    std::vector<DistItem> result;
+    extract_items(&heap, &result);
+
+    ASSERT_EQ(1u, result.size());
+    EXPECT_EQ(10u, result[0].id);
+    EXPECT_DOUBLE_EQ(0.0, result[0].score);
+    EXPECT_EQ(1u, g_counting_dot_calls);
+}
+
+TEST_F(ScannerTest, L2StoredNormScanRefreshesCachedBoundsWhenHeapThresholdTightens) {
+    write_input_raw(
+        input_path_,
+        "f32,4\n"
+        "10 : [ 10.0, 0.0, 0.0, 0.0 ]\n"
+        "20 : [ 1.0, 0.0, 0.0, 0.0 ]\n"
+        "30 : [ 2.0, 0.0, 0.0, 0.0 ]\n"
+        "40 : [ 3.0, 0.0, 0.0, 0.0 ]\n");
+
+    const std::string dataset_dir = data_path_ + ".dataset_" + std::to_string(cleanup_dirs_.size());
+    cleanup_dirs_.push_back(dataset_dir);
+    fs::create_directories(dataset_dir);
+
+    DatasetNode ds;
+    ASSERT_EQ(0, ds.init_for_test({dataset_dir}, 100, DataType::f32, 4, DistFunc::L2).code());
+    ASSERT_EQ(0, ds.store(input_path_).code());
+
+    DataReader reader;
+    ASSERT_EQ(0, reader.init(dataset_dir + "/0.data").code());
+
+    const auto q = f32_values({0.0f, 0.0f, 0.0f, 0.0f});
+    const QueryL2Context query{q.data(), 4, 0.0};
+    DistHeap heap(DistItemCompare{DistFunc::L2});
+    heap.reserve(2);
+
+    g_counting_dot_calls = 0;
+    scan_data_reader_with_l2_stored_norms(reader, 2, &heap, counting_f32_dot, query);
+
+    std::vector<DistItem> result;
+    extract_items(&heap, &result);
+
+    ASSERT_EQ(2u, result.size());
+    EXPECT_EQ(20u, result[0].id);
+    EXPECT_DOUBLE_EQ(1.0, result[0].score);
+    EXPECT_EQ(30u, result[1].id);
+    EXPECT_DOUBLE_EQ(4.0, result[1].score);
+    EXPECT_EQ(3u, g_counting_dot_calls);
 }
 
 TEST_F(ScannerTest, FindDatasetCosWorks) {

--- a/src/core/compute/utest_scanner_ex.cpp
+++ b/src/core/compute/utest_scanner_ex.cpp
@@ -786,7 +786,7 @@ TEST_F(ScannerTest, L2StoredNormScanSkipsDotWhenNormLowerBoundCannotBeatHeap) {
     heap.reserve(1);
 
     g_counting_dot_calls = 0;
-    scan_data_reader_with_l2_stored_norms(reader, 1, &heap, counting_f32_dot, query);
+    scan_data_reader_with_l2_stored_norms<counting_f32_dot>(reader, 1, &heap, query);
 
     std::vector<DistItem> result;
     extract_items(&heap, &result);
@@ -823,7 +823,7 @@ TEST_F(ScannerTest, L2StoredNormScanRefreshesCachedBoundsWhenHeapThresholdTighte
     heap.reserve(2);
 
     g_counting_dot_calls = 0;
-    scan_data_reader_with_l2_stored_norms(reader, 2, &heap, counting_f32_dot, query);
+    scan_data_reader_with_l2_stored_norms<counting_f32_dot>(reader, 2, &heap, query);
 
     std::vector<DistItem> result;
     extract_items(&heap, &result);
@@ -861,7 +861,7 @@ TEST_F(ScannerTest, CosStoredNormScanSkipsDotForZeroStoredVector) {
     heap.reserve(2);
 
     g_counting_dot_calls = 0;
-    scan_data_reader_with_cos_stored_norms(reader, 2, &heap, counting_f32_dot, query);
+    scan_data_reader_with_cos_stored_norms<counting_f32_dot>(reader, 2, &heap, query);
 
     std::vector<DistItem> result;
     extract_items(&heap, &result);
@@ -899,7 +899,7 @@ TEST_F(ScannerTest, CosStoredNormScanTreatsBothZeroVectorsAsExactMatchWithoutDot
     heap.reserve(2);
 
     g_counting_dot_calls = 0;
-    scan_data_reader_with_cos_stored_norms(reader, 2, &heap, counting_f32_dot, query);
+    scan_data_reader_with_cos_stored_norms<counting_f32_dot>(reader, 2, &heap, query);
 
     std::vector<DistItem> result;
     extract_items(&heap, &result);

--- a/src/core/compute/utest_scanner_ex.cpp
+++ b/src/core/compute/utest_scanner_ex.cpp
@@ -175,9 +175,12 @@ protected:
         ASSERT_EQ(static_cast<ssize_t>(sizeof(hdr)), pread(fd, &hdr, sizeof(hdr), 0));
         ASSERT_TRUE(data_file_has_norms(hdr));
         ASSERT_LT(index, static_cast<size_t>(hdr.count));
+        const DataRecordLayout record_layout = compute_data_record_layout(
+            data_type_from_int(static_cast<int>(hdr.type)), hdr.dim, true);
 
         const off_t norm_offset =
-            static_cast<off_t>(hdr.norms_offset + index * sizeof(float));
+            static_cast<off_t>(
+                hdr.data_offset + index * static_cast<size_t>(hdr.vector_stride) + record_layout.norm_offset);
         ASSERT_EQ(static_cast<ssize_t>(sizeof(value)),
                   pwrite(fd, &value, sizeof(value), norm_offset));
         ASSERT_EQ(0, close(fd));

--- a/src/core/compute/utest_scanner_ex.cpp
+++ b/src/core/compute/utest_scanner_ex.cpp
@@ -836,6 +836,82 @@ TEST_F(ScannerTest, L2StoredNormScanRefreshesCachedBoundsWhenHeapThresholdTighte
     EXPECT_EQ(3u, g_counting_dot_calls);
 }
 
+TEST_F(ScannerTest, CosStoredNormScanSkipsDotForZeroStoredVector) {
+    write_input_raw(
+        input_path_,
+        "f32,4\n"
+        "10 : [ 0.0, 0.0, 0.0, 0.0 ]\n"
+        "20 : [ 1.0, 0.0, 0.0, 0.0 ]\n");
+
+    const std::string dataset_dir = data_path_ + ".dataset_" + std::to_string(cleanup_dirs_.size());
+    cleanup_dirs_.push_back(dataset_dir);
+    fs::create_directories(dataset_dir);
+
+    DatasetNode ds;
+    ASSERT_EQ(0, ds.init_for_test({dataset_dir}, 100, DataType::f32, 4, DistFunc::COS).code());
+    ASSERT_EQ(0, ds.store(input_path_).code());
+
+    DataReader reader;
+    ASSERT_EQ(0, reader.init(dataset_dir + "/0.data").code());
+
+    const auto q = f32_values({1.0f, 0.0f, 0.0f, 0.0f});
+    const double query_norm_sq = 1.0;
+    const QueryCosContext query{q.data(), 4, query_norm_sq, query_inverse_norm(query_norm_sq)};
+    DistHeap heap(DistItemCompare{DistFunc::COS});
+    heap.reserve(2);
+
+    g_counting_dot_calls = 0;
+    scan_data_reader_with_cos_stored_norms(reader, 2, &heap, counting_f32_dot, query);
+
+    std::vector<DistItem> result;
+    extract_items(&heap, &result);
+
+    ASSERT_EQ(2u, result.size());
+    EXPECT_EQ(20u, result[0].id);
+    EXPECT_DOUBLE_EQ(0.0, result[0].score);
+    EXPECT_EQ(10u, result[1].id);
+    EXPECT_DOUBLE_EQ(1.0, result[1].score);
+    EXPECT_EQ(1u, g_counting_dot_calls);
+}
+
+TEST_F(ScannerTest, CosStoredNormScanTreatsBothZeroVectorsAsExactMatchWithoutDot) {
+    write_input_raw(
+        input_path_,
+        "f32,4\n"
+        "10 : [ 0.0, 0.0, 0.0, 0.0 ]\n"
+        "20 : [ 1.0, 0.0, 0.0, 0.0 ]\n");
+
+    const std::string dataset_dir = data_path_ + ".dataset_" + std::to_string(cleanup_dirs_.size());
+    cleanup_dirs_.push_back(dataset_dir);
+    fs::create_directories(dataset_dir);
+
+    DatasetNode ds;
+    ASSERT_EQ(0, ds.init_for_test({dataset_dir}, 100, DataType::f32, 4, DistFunc::COS).code());
+    ASSERT_EQ(0, ds.store(input_path_).code());
+
+    DataReader reader;
+    ASSERT_EQ(0, reader.init(dataset_dir + "/0.data").code());
+
+    const auto q = f32_values({0.0f, 0.0f, 0.0f, 0.0f});
+    const double query_norm_sq = 0.0;
+    const QueryCosContext query{q.data(), 4, query_norm_sq, query_inverse_norm(query_norm_sq)};
+    DistHeap heap(DistItemCompare{DistFunc::COS});
+    heap.reserve(2);
+
+    g_counting_dot_calls = 0;
+    scan_data_reader_with_cos_stored_norms(reader, 2, &heap, counting_f32_dot, query);
+
+    std::vector<DistItem> result;
+    extract_items(&heap, &result);
+
+    ASSERT_EQ(2u, result.size());
+    EXPECT_EQ(10u, result[0].id);
+    EXPECT_DOUBLE_EQ(0.0, result[0].score);
+    EXPECT_EQ(20u, result[1].id);
+    EXPECT_DOUBLE_EQ(1.0, result[1].score);
+    EXPECT_EQ(1u, g_counting_dot_calls);
+}
+
 TEST_F(ScannerTest, FindDatasetCosWorks) {
     write_input_raw(
         input_path_,

--- a/src/core/storage/DESIGN.md
+++ b/src/core/storage/DESIGN.md
@@ -114,20 +114,20 @@ DataWriter
 A class that gets generates sealed data file based on the content of InputReader.
 Format:
 
-|--------|-----------------------------|-------------------|-------------|-------------|
-  header       array of vectors          array of cosine    array of ids   array of
-                                         inverse norms                      deleted ids
+|--------|------------------------------------------|-------------|-------------|
+  header       aligned vector records with optional    array of ids   array of
+               inline stored norm                                     deleted ids
 
 header is a struct DataFileHeader.
-vector is data (see below).
+Each vector record stores the vector payload plus optional inline norm data in the same stride-sized slot.
 ids is an array of u64.
-cosine inverse norms is an optional array of f32 values present only for cosine datasets.
-Each value is `1.0 / ||vector||` for the matching active vector. Zero vectors store `0.0`.
-The values are intentionally stored as `f32` instead of `f64` to keep the section compact and
+For cosine datasets each active record also stores an inline `f32` inverse norm, `1.0 / ||vector||`.
+Zero vectors store `0.0`.
+The values are intentionally stored as `f32` instead of `f64` to keep each record compact and
 cheap to stream during scans. This is a precision/performance tradeoff: cosine distances that use
-the stored section can differ slightly from recomputing norms in `double`, especially for near-ties.
-For files managed as part of a cosine dataset, Sketch2 requires this section to be present on every
-persisted data/delta file.
+the stored inline value can differ slightly from recomputing norms in `double`, especially for near-ties.
+For files managed as part of a cosine dataset, Sketch2 requires this inline value to be present on every
+persisted data/delta record.
 
 |----------------------------|
       data
@@ -136,16 +136,15 @@ Interface:
     init(input_path, output_path)
     exec()
 
-Position of id in array ids matches position of a corresponding vector
-in array of vectors and, when present, in the cosine inverse-norm array.
+Position of id in array ids matches position of the corresponding vector record.
 
 Create an instance of InputReader and init it with input_path.
 Create a vector<u64>, resize it with InputReader::count() and populate with ids.
 Init DataFileHeader (data_file.h)
 Write output file:
   - write header
-  - iterate over all data(index) in InputReader and write each vector
-  - for cosine datasets, compute one inverse norm per active vector and write the cosine section
+  - iterate over all data(index) in InputReader and write each vector record
+  - for cosine datasets, compute one inverse norm per active vector and store it inline in that record
   - write vector of ids.
 
 
@@ -160,7 +159,7 @@ Interface:
     size()  vector size
     count() number of vectors
     begin() get iterator
-    get_norm(index) f32 stored norm for the matching active vector; throws when the section is absent
+    get_norm(index) f32 stored inline norm for the matching active vector; throws when inline norms are absent
     get(id) u8*
     at(index) u8*
 
@@ -181,7 +180,7 @@ If it is not found, then the vector is deleted.
 Bitset and the map are populated only if a delta DataReader is provided.
 
 Iterator skips deleted vectors by checking the bitset and look up in the map.
-For files with cosine metadata, iterator also exposes the stored inverse norm for each visible vector.
+For files with cosine metadata, iterator also exposes the stored inline inverse norm for each visible vector.
 
 
 Scanner
@@ -212,26 +211,26 @@ caller-provided output buffers before reporting a failure so failed queries do
 not leave stale results behind.
 
 For cosine datasets scanner precomputes the query norm once per search. If a data file
-or accumulator entry contains stored cosine inverse norms, scanner uses:
+or accumulator entry contains stored inline cosine inverse norms, scanner uses:
 
     cosine_distance = 1 - dot(a, q) * inv_norm(a) * inv_norm(q)
 
 That avoids recomputing the stored-vector norm inside the hot scan loop.
-Because persisted inverse norms are stored as `f32`, this fast path may produce slightly different
+Because persisted inverse norms are stored inline as `f32`, this fast path may produce slightly different
 results than recomputing norms in `double`. The expected benefit is lower storage cost and lower
 per-candidate work in cosine-heavy scans.
-Cosine datasets reject persisted files that do not contain the inverse-norm section.
+Cosine datasets reject persisted files that do not contain inline inverse norms.
 
 For L2 datasets scanner likewise precomputes the query squared norm once per search. If a data file
-or accumulator entry contains stored squared norms, scanner uses:
+or accumulator entry contains stored inline squared norms, scanner uses:
 
     l2_distance_sq = norm_sq(a) + norm_sq(q) - 2 * dot(a, q)
 
 That avoids recomputing the stored-vector squared norm inside the hot scan loop.
-Because persisted squared norms are stored as `f32`, this fast path may produce slightly different
+Because persisted squared norms are stored inline as `f32`, this fast path may produce slightly different
 results than recomputing norms in `double`. The expected benefit is lower per-candidate work in
 L2-heavy scans.
-L2 datasets reject persisted files that do not contain the squared-norm section.
+L2 datasets reject persisted files that do not contain inline squared norms.
 
 
 Dataset

--- a/src/core/storage/data_file.h
+++ b/src/core/storage/data_file.h
@@ -35,8 +35,6 @@ struct DataFileHeader {
     uint64_t vectors_bytes; // total bytes in the vector-record region
     uint32_t vector_stride; // bytes between consecutive persisted records, including inline norm/padding
     uint32_t flags; // optional per-record metadata flags, e.g. stored inline norms
-    uint64_t norms_offset; // legacy standalone norms offset; v11 files keep this at 0
-    uint64_t norms_bytes; // legacy standalone norms size; v11 files keep this at 0
     uint64_t ids_offset; // offset from file start to active ids trailer
     uint64_t ids_bytes; // size of active ids section
     uint64_t deleted_ids_offset; // offset from file start to deleted ids section
@@ -44,9 +42,9 @@ struct DataFileHeader {
     uint64_t reserved = 0;
 };
 
-static_assert(sizeof(DataFileHeader) == 120, "Unexpected DataFileHeader size");
+static_assert(sizeof(DataFileHeader) == 104, "Unexpected DataFileHeader size");
 
-// Data file payload contract (v11):
+// Data file payload contract (v12):
 // 1) aligned vector records with optional inline norm
 // 2) region-alignment padding
 // 3) CompactIdsOffsets(active ids)

--- a/src/core/storage/data_file.h
+++ b/src/core/storage/data_file.h
@@ -46,14 +46,12 @@ struct DataFileHeader {
 
 static_assert(sizeof(DataFileHeader) == 120, "Unexpected DataFileHeader size");
 
-// Data file payload contract (v10):
-// 1) aligned vector records
+// Data file payload contract (v11):
+// 1) aligned vector records with optional inline norm
 // 2) region-alignment padding
-// 3) optional norms for active vectors
+// 3) CompactIdsOffsets(active ids)
 // 4) region-alignment padding
-// 5) CompactIdsOffsets(active ids)
-// 6) region-alignment padding
-// 7) CompactIdsOffsets(deleted ids)
+// 5) CompactIdsOffsets(deleted ids)
 
 struct WalFileHeader {
     BaseFileHeader base;

--- a/src/core/storage/data_file.h
+++ b/src/core/storage/data_file.h
@@ -31,13 +31,13 @@ struct DataFileHeader {
     uint32_t deleted_count;
     uint16_t type;     // data type
     uint16_t dim;
-    uint64_t data_offset; // offset from file start to vectors section
-    uint64_t vectors_bytes; // total bytes in the vectors section
-    uint32_t vector_stride; // bytes between consecutive persisted vectors, including padding
-    uint32_t flags; // optional section flags, e.g. stored norms
-    uint64_t norms_offset; // offset from file start to the optional norms section
-    uint64_t norms_bytes; // size of the optional norms section
-    uint64_t ids_offset; // offset from file start to active ids section
+    uint64_t data_offset; // offset from file start to the aligned vector-record region
+    uint64_t vectors_bytes; // total bytes in the vector-record region
+    uint32_t vector_stride; // bytes between consecutive persisted records, including inline norm/padding
+    uint32_t flags; // optional per-record metadata flags, e.g. stored inline norms
+    uint64_t norms_offset; // legacy standalone norms offset; v11 files keep this at 0
+    uint64_t norms_bytes; // legacy standalone norms size; v11 files keep this at 0
+    uint64_t ids_offset; // offset from file start to active ids trailer
     uint64_t ids_bytes; // size of active ids section
     uint64_t deleted_ids_offset; // offset from file start to deleted ids section
     uint64_t deleted_ids_bytes; // size of deleted ids section

--- a/src/core/storage/data_file_layout.h
+++ b/src/core/storage/data_file_layout.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "core/storage/data_file.h"
 #include "utils/shared_types.h"
+#include <cassert>
 #include <cstdio>
 #include <stdexcept>
 #include <string>
@@ -248,6 +249,7 @@ inline Ret write_data_record(FILE* f,
     const size_t bytes_before_norm = norm != nullptr
         ? layout.norm_offset - layout.vector_size
         : static_cast<size_t>(layout.stride) - layout.vector_size;
+    assert(bytes_before_norm <= sizeof(kZeroPadding));
     if (bytes_before_norm > sizeof(kZeroPadding)) {
         return Ret(context + ": invalid vector padding size");
     }
@@ -261,6 +263,7 @@ inline Ret write_data_record(FILE* f,
         }
         const size_t bytes_after_norm =
             static_cast<size_t>(layout.stride) - (layout.norm_offset + sizeof(float));
+        assert(bytes_after_norm <= sizeof(kZeroPadding));
         if (bytes_after_norm > sizeof(kZeroPadding)) {
             return Ret(context + ": invalid inline norm padding size");
         }

--- a/src/core/storage/data_file_layout.h
+++ b/src/core/storage/data_file_layout.h
@@ -14,14 +14,12 @@ namespace sketch2 {
 struct DataRecordLayout {
     size_t vector_size = 0;
     size_t norm_offset = 0;
-    uint32_t stride = 0;
+    size_t stride = 0;
 };
 
 struct DataMetadataLayout {
     size_t vectors_bytes = 0;
     size_t vectors_padding = 0;
-    size_t norms_offset = 0;
-    size_t norms_bytes = 0;
     size_t ids_trailer_offset = 0;
     size_t ids_trailer_padding = 0;
     size_t deleted_ids_offset = 0;
@@ -98,8 +96,7 @@ inline DataRecordLayout compute_data_record_layout(DataType type, uint16_t dim, 
     DataRecordLayout layout{};
     layout.vector_size = vector_size;
     layout.norm_offset = norm_offset;
-    layout.stride = static_cast<uint32_t>(align_up<size_t>(
-        norm_offset + norm_bytes, static_cast<size_t>(kDataAlignment)));
+    layout.stride = align_up<size_t>(norm_offset + norm_bytes, static_cast<size_t>(kDataAlignment));
     return layout;
 }
 
@@ -136,7 +133,8 @@ inline DataFileHeader make_data_header(uint64_t min_id, uint64_t max_id,
     hdr.dim = dim;
     hdr.data_offset = static_cast<uint64_t>(compute_data_region_offset(sizeof(DataFileHeader)));
     hdr.flags = norm_flags;
-    hdr.vector_stride = compute_data_record_layout(type, dim, data_file_has_norms(hdr)).stride;
+    hdr.vector_stride =
+        static_cast<uint32_t>(compute_data_record_layout(type, dim, data_file_has_norms(hdr)).stride);
     return hdr;
 }
 
@@ -144,8 +142,6 @@ inline DataMetadataLayout compute_data_metadata_layout(const DataFileHeader& hdr
     DataMetadataLayout layout{};
     layout.vectors_bytes = count * static_cast<size_t>(hdr.vector_stride);
     const size_t after_vectors = static_cast<size_t>(hdr.data_offset) + layout.vectors_bytes;
-    layout.norms_offset = 0;
-    layout.norms_bytes = 0;
     layout.ids_trailer_offset = compute_data_region_offset(after_vectors);
     layout.vectors_padding = layout.ids_trailer_offset - after_vectors;
     layout.ids_trailer_padding = 0;
@@ -161,8 +157,6 @@ inline Ret set_data_header_layout(DataFileHeader* hdr, size_t ids_bytes, size_t 
     const size_t deleted_ids_offset = compute_deleted_ids_offset(layout.ids_trailer_offset, ids_bytes);
 
     hdr->vectors_bytes = static_cast<uint64_t>(layout.vectors_bytes);
-    hdr->norms_offset = 0;
-    hdr->norms_bytes = 0;
     hdr->ids_offset = static_cast<uint64_t>(layout.ids_trailer_offset);
     hdr->ids_bytes = static_cast<uint64_t>(ids_bytes);
     hdr->deleted_ids_offset = static_cast<uint64_t>(deleted_ids_offset);
@@ -248,7 +242,9 @@ inline Ret write_data_record(FILE* f,
     constexpr uint8_t kZeroPadding[kDataAlignment] = {};
     const size_t bytes_before_norm = norm != nullptr
         ? layout.norm_offset - layout.vector_size
-        : static_cast<size_t>(layout.stride) - layout.vector_size;
+        : layout.stride - layout.vector_size;
+    // Valid layouts keep padding within one alignment block; retain the runtime guard so
+    // release builds still fail cleanly if a caller constructs a malformed layout by hand.
     assert(bytes_before_norm <= sizeof(kZeroPadding));
     if (bytes_before_norm > sizeof(kZeroPadding)) {
         return Ret(context + ": invalid vector padding size");
@@ -261,8 +257,8 @@ inline Ret write_data_record(FILE* f,
         if (fwrite(norm, sizeof(float), 1, f) != 1) {
             return Ret(context + ": failed to write inline norm");
         }
-        const size_t bytes_after_norm =
-            static_cast<size_t>(layout.stride) - (layout.norm_offset + sizeof(float));
+        const size_t bytes_after_norm = layout.stride - (layout.norm_offset + sizeof(float));
+        // Same belt-and-suspenders check as above for malformed externally-constructed layouts.
         assert(bytes_after_norm <= sizeof(kZeroPadding));
         if (bytes_after_norm > sizeof(kZeroPadding)) {
             return Ret(context + ": invalid inline norm padding size");

--- a/src/core/storage/data_file_layout.h
+++ b/src/core/storage/data_file_layout.h
@@ -134,8 +134,8 @@ inline DataFileHeader make_data_header(uint64_t min_id, uint64_t max_id,
     hdr.type = static_cast<uint16_t>(data_type_to_int(type));
     hdr.dim = dim;
     hdr.data_offset = static_cast<uint64_t>(compute_data_region_offset(sizeof(DataFileHeader)));
-    hdr.vector_stride = compute_vector_stride(compute_vector_size(type, dim));
     hdr.flags = norm_flags;
+    hdr.vector_stride = compute_data_record_layout(type, dim, data_file_has_norms(hdr)).stride;
     return hdr;
 }
 
@@ -143,16 +143,11 @@ inline DataMetadataLayout compute_data_metadata_layout(const DataFileHeader& hdr
     DataMetadataLayout layout{};
     layout.vectors_bytes = count * static_cast<size_t>(hdr.vector_stride);
     const size_t after_vectors = static_cast<size_t>(hdr.data_offset) + layout.vectors_bytes;
-    layout.norms_offset = compute_data_region_offset(after_vectors);
-    layout.norms_bytes = data_file_has_norms(hdr) ? count * sizeof(float) : 0;
-    layout.vectors_padding = data_file_has_norms(hdr)
-        ? layout.norms_offset - after_vectors
-        : 0;
-    const size_t after_norms = data_file_has_norms(hdr)
-        ? layout.norms_offset + layout.norms_bytes
-        : after_vectors;
-    layout.ids_trailer_offset = compute_data_region_offset(after_norms);
-    layout.ids_trailer_padding = layout.ids_trailer_offset - after_norms;
+    layout.norms_offset = 0;
+    layout.norms_bytes = 0;
+    layout.ids_trailer_offset = compute_data_region_offset(after_vectors);
+    layout.vectors_padding = layout.ids_trailer_offset - after_vectors;
+    layout.ids_trailer_padding = 0;
     return layout;
 }
 
@@ -165,8 +160,8 @@ inline Ret set_data_header_layout(DataFileHeader* hdr, size_t ids_bytes, size_t 
     const size_t deleted_ids_offset = compute_deleted_ids_offset(layout.ids_trailer_offset, ids_bytes);
 
     hdr->vectors_bytes = static_cast<uint64_t>(layout.vectors_bytes);
-    hdr->norms_offset = static_cast<uint64_t>(layout.norms_offset);
-    hdr->norms_bytes = static_cast<uint64_t>(layout.norms_bytes);
+    hdr->norms_offset = 0;
+    hdr->norms_bytes = 0;
     hdr->ids_offset = static_cast<uint64_t>(layout.ids_trailer_offset);
     hdr->ids_bytes = static_cast<uint64_t>(ids_bytes);
     hdr->deleted_ids_offset = static_cast<uint64_t>(deleted_ids_offset);
@@ -204,16 +199,6 @@ inline Ret rewrite_header(FILE* f, const DataFileHeader& hdr, const std::string&
     return Ret(0);
 }
 
-inline Ret write_f32_array(FILE* f, const std::vector<float>& values, const std::string& error_message) {
-    if (values.empty()) {
-        return Ret(0);
-    }
-    if (fwrite(values.data(), sizeof(float), values.size(), f) != values.size()) {
-        return Ret(error_message);
-    }
-    return Ret(0);
-}
-
 inline Ret write_vector_record(FILE* f, const uint8_t* data, size_t vec_size, size_t vector_stride,
         const std::string& context) {
     if (data == nullptr) {
@@ -238,6 +223,61 @@ inline Ret write_vector_record(FILE* f, const uint8_t* data, size_t vec_size, si
         return Ret(context + ": failed to write vector padding");
     }
     return Ret(0);
+}
+
+inline Ret write_data_record(FILE* f,
+        const uint8_t* data,
+        const DataRecordLayout& layout,
+        const float* norm,
+        const std::string& context) {
+    if (data == nullptr) {
+        return Ret(context + ": missing vector data");
+    }
+    if (layout.vector_size == 0 || layout.stride < layout.vector_size) {
+        return Ret(context + ": invalid vector stride");
+    }
+    if (norm != nullptr && layout.norm_offset + sizeof(float) > layout.stride) {
+        return Ret(context + ": invalid inline norm layout");
+    }
+
+    if (fwrite(data, layout.vector_size, 1, f) != 1) {
+        return Ret(context + ": failed to write vector data");
+    }
+
+    constexpr uint8_t kZeroPadding[kDataAlignment] = {};
+    const size_t bytes_before_norm = norm != nullptr
+        ? layout.norm_offset - layout.vector_size
+        : static_cast<size_t>(layout.stride) - layout.vector_size;
+    if (bytes_before_norm > sizeof(kZeroPadding)) {
+        return Ret(context + ": invalid vector padding size");
+    }
+    if (bytes_before_norm > 0 && fwrite(kZeroPadding, 1, bytes_before_norm, f) != bytes_before_norm) {
+        return Ret(context + ": failed to write vector padding");
+    }
+
+    if (norm != nullptr) {
+        if (fwrite(norm, sizeof(float), 1, f) != 1) {
+            return Ret(context + ": failed to write inline norm");
+        }
+        const size_t bytes_after_norm =
+            static_cast<size_t>(layout.stride) - (layout.norm_offset + sizeof(float));
+        if (bytes_after_norm > sizeof(kZeroPadding)) {
+            return Ret(context + ": invalid inline norm padding size");
+        }
+        if (bytes_after_norm > 0 && fwrite(kZeroPadding, 1, bytes_after_norm, f) != bytes_after_norm) {
+            return Ret(context + ": failed to write inline norm padding");
+        }
+    }
+
+    return Ret(0);
+}
+
+inline Ret write_vector_record_with_optional_norm(FILE* f,
+        const uint8_t* data,
+        const DataRecordLayout& layout,
+        const float* norm,
+        const std::string& context) {
+    return write_data_record(f, data, layout, norm, context);
 }
 
 } // namespace sketch2

--- a/src/core/storage/data_file_layout.h
+++ b/src/core/storage/data_file_layout.h
@@ -272,12 +272,4 @@ inline Ret write_data_record(FILE* f,
     return Ret(0);
 }
 
-inline Ret write_vector_record_with_optional_norm(FILE* f,
-        const uint8_t* data,
-        const DataRecordLayout& layout,
-        const float* norm,
-        const std::string& context) {
-    return write_data_record(f, data, layout, norm, context);
-}
-
 } // namespace sketch2

--- a/src/core/storage/data_file_layout.h
+++ b/src/core/storage/data_file_layout.h
@@ -10,6 +10,12 @@
 
 namespace sketch2 {
 
+struct DataRecordLayout {
+    size_t vector_size = 0;
+    size_t norm_offset = 0;
+    uint32_t stride = 0;
+};
+
 struct DataMetadataLayout {
     size_t vectors_bytes = 0;
     size_t vectors_padding = 0;
@@ -81,6 +87,19 @@ inline bool dataset_requires_stored_norms(DistFunc dist_func) {
 
 inline size_t compute_vector_size(DataType type, uint16_t dim) {
     return static_cast<size_t>(dim) * data_type_size(type);
+}
+
+inline DataRecordLayout compute_data_record_layout(DataType type, uint16_t dim, bool has_norms) {
+    const size_t vector_size = compute_vector_size(type, dim);
+    const size_t norm_offset = align_up<size_t>(vector_size, alignof(float));
+    const size_t norm_bytes = has_norms ? sizeof(float) : 0;
+
+    DataRecordLayout layout{};
+    layout.vector_size = vector_size;
+    layout.norm_offset = norm_offset;
+    layout.stride = static_cast<uint32_t>(align_up<size_t>(
+        norm_offset + norm_bytes, static_cast<size_t>(kDataAlignment)));
+    return layout;
 }
 
 inline uint32_t compute_vector_stride(size_t vec_size) {

--- a/src/core/storage/data_merger.cpp
+++ b/src/core/storage/data_merger.cpp
@@ -24,45 +24,6 @@ namespace sketch2 {
 
 namespace {
 
-class NormOutput {
-public:
-    explicit NormOutput(bool enabled) : enabled_(enabled) {}
-
-    // The norms side-array is optional in the on-disk format. This helper lets
-    // the merge code always "push" norms while internally becoming a no-op when
-    // the current dataset layout does not persist them.
-    void reserve(size_t count) {
-        if (enabled_) {
-            values_.reserve(count);
-        }
-    }
-
-    void push(float value) {
-        if (enabled_) {
-            values_.push_back(value);
-        }
-    }
-
-    void assert_matches(size_t count) const {
-#ifndef NDEBUG
-        assert(!enabled_ || values_.size() == count);
-#else
-        (void)count;
-#endif
-    }
-
-    Ret write(FILE* f, const char* context) const {
-        return write_f32_array(
-            f,
-            values_,
-            std::string(context) + ": failed to write stored norms");
-    }
-
-private:
-    bool enabled_ = false;
-    std::vector<float> values_;
-};
-
 // Small forward declarations so the RAII helpers below can call the low-level
 // file utilities that are defined later in this anonymous namespace.
 void set_merge_file_buffer(FILE* f, std::vector<char>* file_buffer);
@@ -145,27 +106,23 @@ public:
         : f_(f),
           type_(data_type_from_int(static_cast<int>(header.type))),
           dim_(header.dim),
-          vector_size_(compute_vector_size(type_, dim_)),
-          vector_stride_(header.vector_stride),
+          record_layout_(compute_data_record_layout(type_, dim_, data_file_has_norms(header))),
           context_(context),
-          norms_enabled_(data_file_has_norms(header)),
-          norms_(data_file_has_norms(header)) {}
+          norms_enabled_(data_file_has_norms(header)) {}
 
     // The merge emits at most source.count() + updater.count() live rows.
     // Reserving once keeps the hot merge loop simple and avoids reallocations.
     // The text scratch buffer is only needed for direct-input text merges.
     void reserve(size_t count, bool needs_text_buffer) {
         output_ids_capacity_ = count;
-        norms_.reserve(count);
         if (needs_text_buffer) {
-            parsed_text_buffer_.resize(vector_size_);
+            parsed_text_buffer_.resize(record_layout_.vector_size);
         }
     }
 
     // Appends one surviving row to the output in the exact order required by
-    // the file format: first vector records, later the optional norms array and
-    // id array. The ids are buffered here until those trailing sections are
-    // written after all vectors.
+    // the file format: vector record first, ids trailer later. The ids are
+    // buffered here until those trailing sections are written after all rows.
     Ret write_binary_record(uint64_t id, const uint8_t* data, float norm) {
         if (!output_ids_initialized_) {
             output_ids_.init(id, output_ids_capacity_);
@@ -182,8 +139,8 @@ public:
             output_ids_max_ = id;
         }
         output_ids_.add(id);
-        CHECK(write_vector_record(f_, data, vector_size_, vector_stride_, context_));
-        norms_.push(norm);
+        CHECK(write_vector_record_with_optional_norm(
+            f_, data, record_layout_, norms_enabled_ ? &norm : nullptr, context_));
         return Ret(0);
     }
 
@@ -195,8 +152,8 @@ public:
         if (end < start) {
             return Ret("MergeOutputWriter: invalid text vector range");
         }
-        if (parsed_text_buffer_.size() != vector_size_) {
-            parsed_text_buffer_.resize(vector_size_);
+        if (parsed_text_buffer_.size() != record_layout_.vector_size) {
+            parsed_text_buffer_.resize(record_layout_.vector_size);
         }
 
         const Ret parse_ret = comma_delimited
@@ -211,23 +168,19 @@ public:
     }
 
     // Writes the trailer that follows the vector-record area in every merged
-    // file: optional stored norms, alignment padding before ids, and then the
-    // compact active/deleted id sections.
+    // file: alignment padding before ids, then the compact active/deleted id
+    // sections.
     Ret write_ids_section(const DataFileHeader& header,
             const CompactIds& deleted_ids,
-            const char* ids_padding_message,
             const char* ids_message,
             const char* deleted_ids_message) {
         CompactIds output_ids_ext;
         output_ids_.complete_adding();
         CHECK(output_ids_ext.init(output_ids_));
         output_ids_bytes_ = output_ids_ext.serialized_size_bytes();
-        norms_.assert_matches(output_ids_.size());
         const DataMetadataLayout metadata_layout = compute_data_metadata_layout(header, output_ids_.size());
         CHECK(write_zero_padding(f_, metadata_layout.vectors_padding,
-            std::string(context_) + ": failed to write norms alignment padding"));
-        CHECK(norms_.write(f_, context_));
-        CHECK(write_zero_padding(f_, metadata_layout.ids_trailer_padding, ids_padding_message));
+            std::string(context_) + ": failed to write ids alignment padding"));
         CHECK(output_ids_ext.write(f_, ids_message));
         CHECK(write_zero_padding(
             f_,
@@ -248,11 +201,9 @@ private:
     FILE* f_ = nullptr;
     DataType type_ = DataType::f32;
     uint16_t dim_ = 0;
-    size_t vector_size_ = 0;
-    size_t vector_stride_ = 0;
+    DataRecordLayout record_layout_{};
     const char* context_ = "";
     bool norms_enabled_ = false;
-    NormOutput norms_;
     CompactIdsAccumulator output_ids_;
     size_t output_ids_capacity_ = 0;
     size_t output_ids_bytes_ = 0;
@@ -761,7 +712,6 @@ Ret DataMerger::merge_data_file_(const DataReader& source, const DataReader& upd
     CHECK(output.write_ids_section(
         *merge_file.header(),
         {},
-        "DataMerger::merge_data_files: failed to write id alignment padding",
         "DataMerger::merge_data_files: failed to write ids to merge file",
         "DataMerger::merge_data_files: failed to write deleted_ids to merge file"));
 
@@ -885,7 +835,6 @@ Ret DataMerger::merge_delta_file_(const DataReader& source, const DataReader& up
     CHECK(output.write_ids_section(
         *merge_file.header(),
         compact_deleted_ids,
-        "DataMerger::merge_delta_file: failed to write id alignment padding",
         "DataMerger::merge_delta_file: failed to write ids to merge file",
         "DataMerger::merge_delta_file: failed to write deleted_ids to merge file"));
 
@@ -931,7 +880,6 @@ Ret DataMerger::merge_data_file_(const DataReader& source, const InputReaderView
     CHECK(output.write_ids_section(
         *merge_file.header(),
         empty_deleted_ids,
-        "DataMerger::merge_data_files: failed to write id alignment padding",
         "DataMerger::merge_data_files: failed to write ids to merge file",
         "DataMerger::merge_data_files: failed to write deleted_ids to merge file"));
 
@@ -991,7 +939,6 @@ Ret DataMerger::merge_delta_file_(const DataReader& source, const InputReaderVie
     CHECK(output.write_ids_section(
         *merge_file.header(),
         compact_deleted_ids,
-        "DataMerger::merge_delta_file: failed to write id alignment padding",
         "DataMerger::merge_delta_file: failed to write ids to merge file",
         "DataMerger::merge_delta_file: failed to write deleted_ids to merge file"));
 

--- a/src/core/storage/data_merger.cpp
+++ b/src/core/storage/data_merger.cpp
@@ -220,7 +220,8 @@ public:
     // We intentionally iterate updater base rows only. Merge entry points reject
     // updater files with attached deltas, so base_begin() is equivalent to
     // begin() here and avoids pulling delta semantics into this cursor.
-    explicit DataReaderUpdaterCursor(const DataReader& reader) : iter_(reader.base_begin()) {}
+    explicit DataReaderUpdaterCursor(const DataReader& reader, uint32_t target_norm_flags)
+        : reader_(&reader), iter_(reader.base_begin()), target_norm_flags_(target_norm_flags) {}
 
     bool eof() const { return iter_.eof(); }
     uint64_t id() const { return iter_.id(); }
@@ -240,12 +241,25 @@ public:
     }
 
     Ret write_current(MergeOutputWriter* output) const {
-        const float norm = output->norms_enabled() ? iter_.get_norm() : 0.0f;
+        float norm = 0.0f;
+        if (output->norms_enabled()) {
+            if (reader_->norm_flags() == target_norm_flags_) {
+                norm = iter_.get_norm();
+            } else {
+                norm = compute_stored_norm_for_dist(
+                    iter_.data(),
+                    reader_->type(),
+                    reader_->dim(),
+                    dist_func_for_data_file_norm_flags(target_norm_flags_));
+            }
+        }
         return output->write_binary_record(iter_.id(), iter_.data(), norm);
     }
 
 private:
+    const DataReader* reader_ = nullptr;
     DataReader::OrderedIterator iter_;
+    uint32_t target_norm_flags_ = 0;
 };
 
 class DataReaderDeletedCursor {
@@ -703,7 +717,7 @@ Ret DataMerger::merge_data_file_(const DataReader& source, const DataReader& upd
     output.reserve(source.count() + updater.count(), false);
     CHECK(merge_records(
         source,
-        DataReaderUpdaterCursor(updater),
+        DataReaderUpdaterCursor(updater, source.norm_flags()),
         DataReaderDeletedCursor(updater),
         DataReaderDeletedCursor(updater),
         source.norm_flags(),
@@ -808,7 +822,7 @@ Ret DataMerger::merge_delta_file_(const DataReader& source, const DataReader& up
     // Delta-to-delta merge keeps a tombstone section, but it must first remove
     // any old deletes that the updater resurrected as live rows.
     const std::vector<uint64_t> updater_live_ids =
-        collect_updater_live_ids(DataReaderUpdaterCursor(updater), updater.count());
+        collect_updater_live_ids(DataReaderUpdaterCursor(updater, source.norm_flags()), updater.count());
     CompactIdsAccumulator compact_deleted_ids_accum;
     CHECK(build_compact_accumulator(
         make_data_reader_delta_delete_cursor(source, updater, &updater_live_ids),
@@ -827,7 +841,7 @@ Ret DataMerger::merge_delta_file_(const DataReader& source, const DataReader& up
         make_data_reader_delta_delete_cursor(source, updater, &updater_live_ids);
     CHECK(merge_records(
         source,
-        DataReaderUpdaterCursor(updater),
+        DataReaderUpdaterCursor(updater, source.norm_flags()),
         merge_deleted_cursor,
         merge_deleted_cursor,
         source.norm_flags(),

--- a/src/core/storage/data_merger.cpp
+++ b/src/core/storage/data_merger.cpp
@@ -121,8 +121,9 @@ public:
     }
 
     // Appends one surviving row to the output in the exact order required by
-    // the file format: vector record first, ids trailer later. The ids are
-    // buffered here until those trailing sections are written after all rows.
+    // the file format: a full inline record first, then the ids trailer later.
+    // The ids are buffered here until those trailing sections are written
+    // after all rows.
     Ret write_binary_record(uint64_t id, const uint8_t* data, float norm) {
         if (!output_ids_initialized_) {
             output_ids_.init(id, output_ids_capacity_);
@@ -139,7 +140,7 @@ public:
             output_ids_max_ = id;
         }
         output_ids_.add(id);
-        CHECK(write_vector_record_with_optional_norm(
+        CHECK(write_data_record(
             f_, data, record_layout_, norms_enabled_ ? &norm : nullptr, context_));
         return Ret(0);
     }
@@ -167,9 +168,10 @@ public:
         return write_binary_record(id, parsed_text_buffer_.data(), norm);
     }
 
-    // Writes the trailer that follows the vector-record area in every merged
+    // Writes the trailer that follows the inline record area in every merged
     // file: alignment padding before ids, then the compact active/deleted id
-    // sections.
+    // sections. Norms live inside each record, so there is no separate norms
+    // section between vectors and ids.
     Ret write_ids_section(const DataFileHeader& header,
             const CompactIds& deleted_ids,
             const char* ids_message,

--- a/src/core/storage/data_reader.cpp
+++ b/src/core/storage/data_reader.cpp
@@ -226,9 +226,6 @@ Ret DataReader::validate_header_and_layout_(size_t file_size, DataMetadataLayout
     if (stride_ < vector_size_ || (stride_ % kDataAlignment) != 0) {
         return Ret("DataReader: invalid vector stride");
     }
-    if (hdr_.norms_offset != 0 || hdr_.norms_bytes != 0) {
-        return Ret("DataReader: v11 data files must not declare a separate norms section");
-    }
     if (data_file_has_norms(hdr_) && stride_ < norm_offset_in_record_ + sizeof(float)) {
         return Ret("DataReader: invalid inline norm layout");
     }
@@ -365,8 +362,6 @@ void DataReader::assert_invariants_() const {
     assert(stride_ >= vector_size_);
     assert((hdr_.data_offset % static_cast<uint64_t>(kDataRegionAlignment)) == 0);
     assert((stride_ % kDataAlignment) == 0);
-    assert(hdr_.norms_offset == 0);
-    assert(hdr_.norms_bytes == 0);
     assert(ids_.count() == hdr_.count);
     assert(deleted_ids_.count() == hdr_.deleted_count);
     assert(!ids_region_.empty());
@@ -375,8 +370,6 @@ void DataReader::assert_invariants_() const {
     const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr_, hdr_.count);
     assert(vectors_region_.size() == metadata_layout.vectors_bytes);
     assert(hdr_.vectors_bytes == metadata_layout.vectors_bytes);
-    assert(hdr_.norms_offset == metadata_layout.norms_offset);
-    assert(hdr_.norms_bytes == metadata_layout.norms_bytes);
     assert(hdr_.ids_offset == metadata_layout.ids_trailer_offset);
     assert(hdr_.ids_bytes == ids_region_.size());
     assert(hdr_.deleted_ids_offset ==

--- a/src/core/storage/data_reader.cpp
+++ b/src/core/storage/data_reader.cpp
@@ -159,6 +159,7 @@ void DataReader::reset_state_() {
     norms_ = nullptr;
     deleted_ids_.clear();
     vector_size_ = 0;
+    norm_offset_ = 0;
     stride_ = 0;
     changed_bitset_.resize(0);
     delta_.reset();
@@ -211,6 +212,7 @@ Ret DataReader::validate_header_and_layout_(size_t file_size, DataMetadataLayout
     }
 
     vector_size_ = dim * elem_size;
+    norm_offset_ = compute_data_record_layout(type_, hdr_.dim, data_file_has_norms(hdr_)).norm_offset;
     stride_ = static_cast<size_t>(hdr_.vector_stride);
     if ((hdr_.flags & ~kDataFileNormKindMask) != 0u) {
         return Ret("DataReader: unsupported data-file flags");
@@ -224,6 +226,9 @@ Ret DataReader::validate_header_and_layout_(size_t file_size, DataMetadataLayout
     }
     if (stride_ < vector_size_ || (stride_ % kDataAlignment) != 0) {
         return Ret("DataReader: invalid vector stride");
+    }
+    if (data_file_has_norms(hdr_) && stride_ < norm_offset_ + sizeof(float)) {
+        return Ret("DataReader: invalid inline norm layout");
     }
 
     *metadata_layout = compute_data_metadata_layout(hdr_, hdr_.count);
@@ -265,9 +270,6 @@ Ret DataReader::map_regions_(int fd, size_t file_size, const DataMetadataLayout&
     if (metadata_layout.vectors_bytes > 0) {
         CHECK(vectors_region_.init(fd, hdr_.data_offset, metadata_layout.vectors_bytes, true));
     }
-    if (metadata_layout.norms_bytes > 0) {
-        CHECK(norms_region_.init(fd, metadata_layout.norms_offset, metadata_layout.norms_bytes, true));
-    }
 
     CHECK(ids_region_.init(fd, hdr_.ids_offset, hdr_.ids_bytes));
     size_t active_ids_bytes = 0;
@@ -298,8 +300,8 @@ Ret DataReader::map_regions_(int fd, size_t file_size, const DataMetadataLayout&
         return Ret("DataReader: ids trailer count does not match header");
     }
 
-    norms_ = metadata_layout.norms_bytes > 0
-        ? reinterpret_cast<const float*>(norms_region_.data())
+    norms_ = (data_file_has_norms(hdr_) && hdr_.count > 0)
+        ? reinterpret_cast<const float*>(vectors_region_.data() + norm_offset_)
         : nullptr;
     return Ret(0);
 }
@@ -349,6 +351,7 @@ void DataReader::assert_invariants_() const {
         assert(norms_ == nullptr);
         assert(deleted_ids_.empty());
         assert(vector_size_ == 0);
+        assert(norm_offset_ == 0);
         assert(stride_ == 0);
         return;
     }
@@ -357,6 +360,7 @@ void DataReader::assert_invariants_() const {
     assert(hdr_.base.kind == static_cast<uint16_t>(FileType::Data));
     assert(hdr_.base.version == kVersion);
     assert(vector_size_ == compute_vector_size(type_, hdr_.dim));
+    assert(norm_offset_ == compute_data_record_layout(type_, hdr_.dim, data_file_has_norms(hdr_)).norm_offset);
     assert(stride_ == hdr_.vector_stride);
     assert(data_file_has_valid_norm_flags(hdr_));
     assert(stride_ >= vector_size_);
@@ -379,8 +383,8 @@ void DataReader::assert_invariants_() const {
         static_cast<uint64_t>(compute_deleted_ids_offset(hdr_.ids_offset, hdr_.ids_bytes)));
     assert(hdr_.deleted_ids_bytes == deleted_ids_region_.size());
 
-    if (data_file_has_norms(hdr_)) {
-        assert(norms_ == reinterpret_cast<const float*>(norms_region_.data()));
+    if (data_file_has_norms(hdr_) && hdr_.count > 0) {
+        assert(norms_ == reinterpret_cast<const float*>(vectors_region_.data() + norm_offset_));
     } else {
         assert(norms_ == nullptr);
     }

--- a/src/core/storage/data_reader.cpp
+++ b/src/core/storage/data_reader.cpp
@@ -79,7 +79,7 @@ Ret DataReader::init(const std::string &path, std::unique_ptr<DataReader> delta)
 }
 
 // Memory-maps a binary data file, validates its layout, and caches pointers to
-// the vector, norms, id, and delete sections. When a delta reader is attached,
+// the vector, id, and delete sections. When a delta reader is attached,
 // it also builds a visibility bitset for base rows shadowed by newer updates.
 Ret DataReader::init_(const std::string& path, std::unique_ptr<DataReader> delta) {
     if (initialized_) {
@@ -152,14 +152,12 @@ void DataReader::reset_state_() {
     vectors_region_.reset();
     ids_region_.reset();
     deleted_ids_region_.reset();
-    norms_region_.reset();
     hdr_ = {};
     initialized_ = false;
     ids_.clear();
-    norms_ = nullptr;
     deleted_ids_.clear();
     vector_size_ = 0;
-    norm_offset_ = 0;
+    norm_offset_in_record_ = 0;
     stride_ = 0;
     changed_bitset_.resize(0);
     delta_.reset();
@@ -212,7 +210,8 @@ Ret DataReader::validate_header_and_layout_(size_t file_size, DataMetadataLayout
     }
 
     vector_size_ = dim * elem_size;
-    norm_offset_ = compute_data_record_layout(type_, hdr_.dim, data_file_has_norms(hdr_)).norm_offset;
+    norm_offset_in_record_ =
+        compute_data_record_layout(type_, hdr_.dim, data_file_has_norms(hdr_)).norm_offset;
     stride_ = static_cast<size_t>(hdr_.vector_stride);
     if ((hdr_.flags & ~kDataFileNormKindMask) != 0u) {
         return Ret("DataReader: unsupported data-file flags");
@@ -227,14 +226,15 @@ Ret DataReader::validate_header_and_layout_(size_t file_size, DataMetadataLayout
     if (stride_ < vector_size_ || (stride_ % kDataAlignment) != 0) {
         return Ret("DataReader: invalid vector stride");
     }
-    if (data_file_has_norms(hdr_) && stride_ < norm_offset_ + sizeof(float)) {
+    if (hdr_.norms_offset != 0 || hdr_.norms_bytes != 0) {
+        return Ret("DataReader: v11 data files must not declare a separate norms section");
+    }
+    if (data_file_has_norms(hdr_) && stride_ < norm_offset_in_record_ + sizeof(float)) {
         return Ret("DataReader: invalid inline norm layout");
     }
 
     *metadata_layout = compute_data_metadata_layout(hdr_, hdr_.count);
     if (hdr_.vectors_bytes != metadata_layout->vectors_bytes
-            || hdr_.norms_offset != metadata_layout->norms_offset
-            || hdr_.norms_bytes != metadata_layout->norms_bytes
             || hdr_.ids_offset != metadata_layout->ids_trailer_offset
             || hdr_.deleted_ids_offset != compute_deleted_ids_offset(hdr_.ids_offset, hdr_.ids_bytes)) {
         return Ret("DataReader: malformed section layout in header");
@@ -260,6 +260,9 @@ Ret DataReader::validate_delta_(const std::unique_ptr<DataReader>& delta) const 
     if (type_ != delta->type_) return Ret("DataReader: invalid delta type");
     if (vector_size_ != delta->vector_size_) return Ret("DataReader: invalid delta dim");
     if (stride_ != delta->stride_) return Ret("DataReader: invalid delta stride");
+    if (norm_offset_in_record_ != delta->norm_offset_in_record_) {
+        return Ret("DataReader: invalid delta norm layout");
+    }
     if (data_file_norm_flags(hdr_) != data_file_norm_flags(delta->hdr_)) {
         return Ret("DataReader: invalid delta norm layout");
     }
@@ -300,9 +303,6 @@ Ret DataReader::map_regions_(int fd, size_t file_size, const DataMetadataLayout&
         return Ret("DataReader: ids trailer count does not match header");
     }
 
-    norms_ = (data_file_has_norms(hdr_) && hdr_.count > 0)
-        ? reinterpret_cast<const float*>(vectors_region_.data() + norm_offset_)
-        : nullptr;
     return Ret(0);
 }
 
@@ -346,12 +346,10 @@ void DataReader::assert_invariants_() const {
         assert(vectors_region_.empty());
         assert(ids_region_.empty());
         assert(deleted_ids_region_.empty());
-        assert(norms_region_.empty());
         assert(ids_.empty());
-        assert(norms_ == nullptr);
         assert(deleted_ids_.empty());
         assert(vector_size_ == 0);
-        assert(norm_offset_ == 0);
+        assert(norm_offset_in_record_ == 0);
         assert(stride_ == 0);
         return;
     }
@@ -360,12 +358,15 @@ void DataReader::assert_invariants_() const {
     assert(hdr_.base.kind == static_cast<uint16_t>(FileType::Data));
     assert(hdr_.base.version == kVersion);
     assert(vector_size_ == compute_vector_size(type_, hdr_.dim));
-    assert(norm_offset_ == compute_data_record_layout(type_, hdr_.dim, data_file_has_norms(hdr_)).norm_offset);
+    assert(norm_offset_in_record_ ==
+        compute_data_record_layout(type_, hdr_.dim, data_file_has_norms(hdr_)).norm_offset);
     assert(stride_ == hdr_.vector_stride);
     assert(data_file_has_valid_norm_flags(hdr_));
     assert(stride_ >= vector_size_);
     assert((hdr_.data_offset % static_cast<uint64_t>(kDataRegionAlignment)) == 0);
     assert((stride_ % kDataAlignment) == 0);
+    assert(hdr_.norms_offset == 0);
+    assert(hdr_.norms_bytes == 0);
     assert(ids_.count() == hdr_.count);
     assert(deleted_ids_.count() == hdr_.deleted_count);
     assert(!ids_region_.empty());
@@ -373,7 +374,6 @@ void DataReader::assert_invariants_() const {
 
     const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr_, hdr_.count);
     assert(vectors_region_.size() == metadata_layout.vectors_bytes);
-    assert(norms_region_.size() == metadata_layout.norms_bytes);
     assert(hdr_.vectors_bytes == metadata_layout.vectors_bytes);
     assert(hdr_.norms_offset == metadata_layout.norms_offset);
     assert(hdr_.norms_bytes == metadata_layout.norms_bytes);
@@ -383,10 +383,8 @@ void DataReader::assert_invariants_() const {
         static_cast<uint64_t>(compute_deleted_ids_offset(hdr_.ids_offset, hdr_.ids_bytes)));
     assert(hdr_.deleted_ids_bytes == deleted_ids_region_.size());
 
-    if (data_file_has_norms(hdr_) && hdr_.count > 0) {
-        assert(norms_ == reinterpret_cast<const float*>(vectors_region_.data() + norm_offset_));
-    } else {
-        assert(norms_ == nullptr);
+    if (data_file_has_norms(hdr_)) {
+        assert(stride_ >= norm_offset_in_record_ + sizeof(float));
     }
 
     if (delta_) {
@@ -394,6 +392,7 @@ void DataReader::assert_invariants_() const {
         assert(type_ == delta_->type());
         assert(vector_size_ == delta_->size());
         assert(stride_ == delta_->stride());
+        assert(norm_offset_in_record_ == delta_->norm_offset_in_record_);
         assert(norm_flags() == delta_->norm_flags());
     } else {
         assert(changed_bitset_.size() == 0);

--- a/src/core/storage/data_reader.cpp
+++ b/src/core/storage/data_reader.cpp
@@ -19,8 +19,8 @@ DataReader::Iterator::Iterator(const DataReader* reader, const DataReader* delta
 
 void DataReader::Iterator::next() {
     ++index_;
-    while (index_ < reader_->count() && reader_->is_hidden(index_)) {
-        ++index_;
+    if (index_ < reader_->count_unchecked()) {
+        index_ = reader_->next_visible_base_index_unchecked(index_);
     }
 }
 
@@ -160,6 +160,7 @@ void DataReader::reset_state_() {
     norm_offset_in_record_ = 0;
     stride_ = 0;
     changed_bitset_.resize(0);
+    has_hidden_rows_ = false;
     delta_.reset();
 }
 
@@ -311,6 +312,7 @@ Ret DataReader::init_delta() {
         return Ret("DataReader::init_delta: reader is not initialized");
     }
 
+    has_hidden_rows_ = false;
     auto mark_hidden = [this](const CompactIds& other_ids) {
         const size_t base_count = ids_.count();
         const size_t other_count = other_ids.count();
@@ -326,6 +328,7 @@ Ret DataReader::init_delta() {
 
             if (other_ids.id_unchecked(j) == id) {
                 changed_bitset_.set(i);
+                has_hidden_rows_ = true;
             }
         }
     };
@@ -383,6 +386,7 @@ void DataReader::assert_invariants_() const {
 
     if (delta_) {
         assert(changed_bitset_.size() == hdr_.count);
+        assert(has_hidden_rows_ == changed_bitset_.any());
         assert(type_ == delta_->type());
         assert(vector_size_ == delta_->size());
         assert(stride_ == delta_->stride());
@@ -390,6 +394,7 @@ void DataReader::assert_invariants_() const {
         assert(norm_flags() == delta_->norm_flags());
     } else {
         assert(changed_bitset_.size() == 0);
+        assert(!has_hidden_rows_);
     }
 #endif
 }
@@ -437,19 +442,11 @@ bool DataReader::has_matching_stored_norms(DistFunc dist_func) const {
 }
 
 DataReader::Iterator DataReader::begin() const {
-    size_t index = 0;
-    while (index < count() && is_hidden(index)) {
-        ++index;
-    }
-    return Iterator(this, delta_ ? delta_.get() : nullptr, index);
+    return Iterator(this, delta_ ? delta_.get() : nullptr, first_visible_base_index_unchecked());
 }
 
 DataReader::OrderedIterator DataReader::base_begin() const {
-    size_t index = 0;
-    while (index < count() && is_hidden(index)) {
-        ++index;
-    }
-    return OrderedIterator(this, OrderedIterator::Source::Base, index);
+    return OrderedIterator(this, OrderedIterator::Source::Base, first_visible_base_index_unchecked());
 }
 
 DataReader::OrderedIterator DataReader::delta_begin() const {
@@ -460,7 +457,7 @@ uint64_t DataReader::id(size_t index) const {
     if (index >= count()) {
         throw std::out_of_range("DataReader::id: index out of range");
     }
-    return ids_.id(index);
+    return id_unchecked(index);
 }
 
 // Looks up an id in the base file and falls back to the attached delta when the

--- a/src/core/storage/data_reader.cpp
+++ b/src/core/storage/data_reader.cpp
@@ -209,9 +209,10 @@ Ret DataReader::validate_header_and_layout_(size_t file_size, DataMetadataLayout
         return Ret("DataReader: dimension too small");
     }
 
-    vector_size_ = dim * elem_size;
-    norm_offset_in_record_ =
-        compute_data_record_layout(type_, hdr_.dim, data_file_has_norms(hdr_)).norm_offset;
+    const DataRecordLayout record_layout =
+        compute_data_record_layout(type_, hdr_.dim, data_file_has_norms(hdr_));
+    vector_size_ = record_layout.vector_size;
+    norm_offset_in_record_ = record_layout.norm_offset;
     stride_ = static_cast<size_t>(hdr_.vector_stride);
     if ((hdr_.flags & ~kDataFileNormKindMask) != 0u) {
         return Ret("DataReader: unsupported data-file flags");
@@ -226,7 +227,7 @@ Ret DataReader::validate_header_and_layout_(size_t file_size, DataMetadataLayout
     if (stride_ < vector_size_ || (stride_ % kDataAlignment) != 0) {
         return Ret("DataReader: invalid vector stride");
     }
-    if (data_file_has_norms(hdr_) && stride_ < norm_offset_in_record_ + sizeof(float)) {
+    if (data_file_has_norms(hdr_) && stride_ != record_layout.stride) {
         return Ret("DataReader: invalid inline norm layout");
     }
 

--- a/src/core/storage/data_reader.h
+++ b/src/core/storage/data_reader.h
@@ -148,7 +148,7 @@ public:
             throw std::logic_error("DataReader::get_norm: norms section is absent");
         }
         float value = 0.0f;
-        std::memcpy(&value, at_unchecked_(index) + norm_offset_, sizeof(value));
+        std::memcpy(&value, vectors_region_.data() + index * stride_ + norm_offset_in_record_, sizeof(value));
         return value;
     }
     const uint8_t* get(uint64_t id) const;   // lookup by vector id
@@ -185,15 +185,13 @@ private:
     MappedRegion             vectors_region_;
     MappedRegion             ids_region_;
     MappedRegion             deleted_ids_region_;
-    MappedRegion             norms_region_;
     DataFileHeader           hdr_     = {};
     bool                     initialized_ = false;
     CompactIds               ids_;
     CompactIds               deleted_ids_;
-    const float*             norms_   = nullptr; // optional stored norms in mapped metadata
     DataType                 type_    = DataType::f32;
     size_t                   vector_size_ = 0;    // size of one vector in bytes
-    size_t                   norm_offset_ = 0;    // inline norm slot within one persisted record
+    size_t                   norm_offset_in_record_ = 0;    // inline norm slot within one persisted record
     size_t                   stride_  = 0;        // bytes between persisted vectors
     std::string              path_ = "<undefined>";
 

--- a/src/core/storage/data_reader.h
+++ b/src/core/storage/data_reader.h
@@ -147,6 +147,9 @@ public:
         if (!data_file_has_norms(hdr_)) {
             throw std::logic_error("DataReader::get_norm: inline norms are absent");
         }
+        if (is_hidden(index)) {
+            throw std::logic_error("DataReader::get_norm: index points to hidden row");
+        }
         float value = 0.0f;
         std::memcpy(&value, vectors_region_.data() + index * stride_ + norm_offset_in_record_, sizeof(value));
         return value;

--- a/src/core/storage/data_reader.h
+++ b/src/core/storage/data_reader.h
@@ -145,7 +145,7 @@ public:
             throw std::out_of_range("DataReader::get_norm: index out of range");
         }
         if (!data_file_has_norms(hdr_)) {
-            throw std::logic_error("DataReader::get_norm: norms section is absent");
+            throw std::logic_error("DataReader::get_norm: inline norms are absent");
         }
         float value = 0.0f;
         std::memcpy(&value, vectors_region_.data() + index * stride_ + norm_offset_in_record_, sizeof(value));

--- a/src/core/storage/data_reader.h
+++ b/src/core/storage/data_reader.h
@@ -7,6 +7,7 @@
 #include "core/utils/mapped_region.h"
 #include "core/storage/data_file.h"
 #include "core/storage/data_file_layout.h"
+#include <cassert>
 #include <cstring>
 #include <cstdint>
 #include <memory>
@@ -140,6 +141,15 @@ public:
     OrderedIterator base_begin() const;
     OrderedIterator delta_begin() const;
     uint64_t       id(size_t index) const;
+    inline float   get_norm_from_record_unchecked(const uint8_t* record) const {
+        assert(initialized_);
+        assert(record != nullptr);
+        assert(data_file_has_norms(hdr_));
+
+        float value = 0.0f;
+        std::memcpy(&value, record + norm_offset_in_record_, sizeof(value));
+        return value;
+    }
     inline float   get_norm(size_t index) const {
         if (index >= count()) {
             throw std::out_of_range("DataReader::get_norm: index out of range");
@@ -150,9 +160,7 @@ public:
         if (is_hidden(index)) {
             throw std::logic_error("DataReader::get_norm: index points to hidden row");
         }
-        float value = 0.0f;
-        std::memcpy(&value, vectors_region_.data() + index * stride_ + norm_offset_in_record_, sizeof(value));
-        return value;
+        return get_norm_from_record_unchecked(vectors_region_.data() + index * stride_);
     }
     const uint8_t* get(uint64_t id) const;   // lookup by vector id
     inline const uint8_t* at(size_t index) const {   // lookup by position; might return nullptr if the vector is deleted

--- a/src/core/storage/data_reader.h
+++ b/src/core/storage/data_reader.h
@@ -53,8 +53,8 @@ public:
             if (!reader_ || source_ != Source::Base) {
                 return;
             }
-            while (index_ < reader_->count() && reader_->is_hidden(index_)) {
-                ++index_;
+            if (index_ < reader_->count_unchecked()) {
+                index_ = reader_->next_visible_base_index_unchecked(index_);
             }
         }
 
@@ -63,9 +63,9 @@ public:
                 return true;
             }
             if (source_ == Source::Base) {
-                return index_ >= reader_->count();
+                return index_ >= reader_->count_unchecked();
             }
-            return !reader_->delta_ || index_ >= reader_->delta_->count();
+            return !reader_->delta_ || index_ >= reader_->delta_->count_unchecked();
         }
 
         inline const uint8_t* data() const {
@@ -74,7 +74,7 @@ public:
             }
 
             if (source_ == Source::Base) {
-                return reader_->at_unchecked_(index_);
+                return reader_->record_unchecked_(index_);
             }
 
             return reader_->delta_->at(index_);
@@ -86,7 +86,10 @@ public:
             }
 
             if (source_ == Source::Base) {
-                return reader_->get_norm(index_);
+                if (!data_file_has_norms(reader_->hdr_)) {
+                    return reader_->get_norm(index_);
+                }
+                return reader_->get_norm_from_record_unchecked(reader_->record_unchecked_(index_));
             }
 
             return reader_->delta_->get_norm(index_);
@@ -98,7 +101,7 @@ public:
             }
 
             if (source_ == Source::Base) {
-                return reader_->ids_.id(index_);
+                return reader_->id_unchecked(index_);
             }
 
             return reader_->delta_->ids_.id(index_);
@@ -131,6 +134,10 @@ public:
         if (!initialized_) {
             throw std::runtime_error("DataReader::count: reader is not initialized");
         }
+        return count_unchecked();
+    }
+    inline size_t count_unchecked() const {
+        assert(initialized_);
         return static_cast<size_t>(hdr_.count);
     }
     uint32_t norm_flags() const;
@@ -141,6 +148,39 @@ public:
     OrderedIterator base_begin() const;
     OrderedIterator delta_begin() const;
     uint64_t       id(size_t index) const;
+    inline uint64_t id_unchecked(size_t index) const {
+        assert(index < count_unchecked());
+        return ids_.id_unchecked(index);
+    }
+    inline const uint8_t* record_unchecked(size_t index) const {
+        return record_unchecked_(index);
+    }
+    inline bool    has_hidden_rows_unchecked() const {
+        assert(initialized_);
+        return has_hidden_rows_;
+    }
+    inline size_t  next_visible_base_index_unchecked(size_t index) const {
+        assert(initialized_);
+        const size_t end = count_unchecked();
+        if (index >= end) {
+            return end;
+        }
+        if (!has_hidden_rows_ || changed_bitset_.empty()) {
+            return index;
+        }
+        return changed_bitset_.find_next_unset(index);
+    }
+    inline size_t  first_visible_base_index_unchecked() const {
+        return next_visible_base_index_unchecked(0);
+    }
+    inline const DataReader* delta_reader_unchecked() const {
+        assert(initialized_);
+        return delta_.get();
+    }
+    inline size_t  norm_offset_in_record_unchecked() const {
+        assert(initialized_);
+        return norm_offset_in_record_;
+    }
     inline float   get_norm_from_record_unchecked(const uint8_t* record) const {
         assert(initialized_);
         assert(record != nullptr);
@@ -168,14 +208,14 @@ public:
             throw std::out_of_range("DataReader::at: index out of range");
         }
 
-        if (index < changed_bitset_.size() && changed_bitset_.get(index)) {
+        if (index < changed_bitset_.size() && changed_bitset_.get_unchecked(index)) {
             return nullptr;
         }
 
-        return vectors_region_.data() + index * stride_;
+        return record_unchecked_(index);
     }
     inline bool    is_hidden(size_t index) const {
-        return (index < changed_bitset_.size() && changed_bitset_.get(index));
+        return (index < changed_bitset_.size() && changed_bitset_.get_unchecked(index));
     }
     std::string    path() const { return path_; }
 
@@ -186,11 +226,13 @@ public:
     bool has_delta() const { return delta_ != nullptr; }
 
 private:
-    inline const uint8_t* at_unchecked_(size_t index) const {
-        if (index >= count()) {
-            throw std::out_of_range("DataReader::at_unchecked_: index out of range");
-        }
+    inline const uint8_t* record_unchecked_(size_t index) const {
+        assert(index < count_unchecked());
         return vectors_region_.data() + index * stride_;
+    }
+
+    inline const uint8_t* at_unchecked_(size_t index) const {
+        return record_unchecked_(index);
     }
 
     MappedRegion             vectors_region_;
@@ -207,6 +249,7 @@ private:
     std::string              path_ = "<undefined>";
 
     DynamicBitset           changed_bitset_;
+    bool                    has_hidden_rows_ = false;
     std::unique_ptr<DataReader> delta_;
 
     Ret init_(const std::string &path, std::unique_ptr<DataReader> delta);

--- a/src/core/storage/data_reader.h
+++ b/src/core/storage/data_reader.h
@@ -7,6 +7,7 @@
 #include "core/utils/mapped_region.h"
 #include "core/storage/data_file.h"
 #include "core/storage/data_file_layout.h"
+#include <cstring>
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
@@ -143,10 +144,12 @@ public:
         if (index >= count()) {
             throw std::out_of_range("DataReader::get_norm: index out of range");
         }
-        if (!norms_) {
+        if (!data_file_has_norms(hdr_)) {
             throw std::logic_error("DataReader::get_norm: norms section is absent");
         }
-        return norms_[index];
+        float value = 0.0f;
+        std::memcpy(&value, at_unchecked_(index) + norm_offset_, sizeof(value));
+        return value;
     }
     const uint8_t* get(uint64_t id) const;   // lookup by vector id
     inline const uint8_t* at(size_t index) const {   // lookup by position; might return nullptr if the vector is deleted
@@ -190,6 +193,7 @@ private:
     const float*             norms_   = nullptr; // optional stored norms in mapped metadata
     DataType                 type_    = DataType::f32;
     size_t                   vector_size_ = 0;    // size of one vector in bytes
+    size_t                   norm_offset_ = 0;    // inline norm slot within one persisted record
     size_t                   stride_  = 0;        // bytes between persisted vectors
     std::string              path_ = "<undefined>";
 

--- a/src/core/storage/data_writer.cpp
+++ b/src/core/storage/data_writer.cpp
@@ -62,21 +62,21 @@ Ret write_vector_section(
         FILE* f,
         const InputReaderView& reader,
         const DataFileHeader& hdr,
-        DistFunc dist_func,
-        std::vector<float>* norms) {
+        DistFunc dist_func) {
     const size_t count = reader.count();
-    const size_t vec_size = reader.size();
     const bool binary_input = reader.is_binary();
-    std::vector<uint8_t> buf = binary_input ? std::vector<uint8_t>() : std::vector<uint8_t>(vec_size);
-    const auto append_norm = [&](const uint8_t* vector_data) {
+    const DataRecordLayout record_layout =
+        compute_data_record_layout(reader.type(), static_cast<uint16_t>(reader.dim()), data_file_has_norms(hdr));
+    std::vector<uint8_t> buf = binary_input ? std::vector<uint8_t>() : std::vector<uint8_t>(record_layout.vector_size);
+    const auto compute_norm = [&](const uint8_t* vector_data, float* norm_value) {
         switch (dist_func) {
             case DistFunc::COS:
-                norms->push_back(static_cast<float>(
-                    compute_cosine_inverse_norm(vector_data, reader.type(), reader.dim())));
+                *norm_value = static_cast<float>(
+                    compute_cosine_inverse_norm(vector_data, reader.type(), reader.dim()));
                 return;
             case DistFunc::L2:
-                norms->push_back(static_cast<float>(
-                    compute_squared_norm(vector_data, reader.type(), reader.dim())));
+                *norm_value = static_cast<float>(
+                    compute_squared_norm(vector_data, reader.type(), reader.dim()));
                 return;
             case DistFunc::DOT:
                 return;
@@ -94,13 +94,18 @@ Ret write_vector_section(
 
             const uint8_t* vector_data = nullptr;
             CHECK(reader.raw_data(i, &vector_data));
-            CHECK(write_vector_record(
+            float norm_value = 0.0f;
+            float* norm_ptr = nullptr;
+            if (data_file_has_norms(hdr)) {
+                compute_norm(vector_data, &norm_value);
+                norm_ptr = &norm_value;
+            }
+            CHECK(write_data_record(
                 f,
                 vector_data,
-                vec_size,
-                hdr.vector_stride,
+                record_layout,
+                norm_ptr,
                 "DataWriter: failed to write vector data at index " + std::to_string(i)));
-            append_norm(vector_data);
         }
         return Ret(0);
     }
@@ -112,13 +117,18 @@ Ret write_vector_section(
 
         CHECK(reader.data(i, buf.data(), buf.size()));
         const uint8_t* vector_data = buf.data();
-        CHECK(write_vector_record(
+        float norm_value = 0.0f;
+        float* norm_ptr = nullptr;
+        if (data_file_has_norms(hdr)) {
+            compute_norm(vector_data, &norm_value);
+            norm_ptr = &norm_value;
+        }
+        CHECK(write_data_record(
             f,
             vector_data,
-            vec_size,
-            hdr.vector_stride,
+            record_layout,
+            norm_ptr,
             "DataWriter: failed to write vector data at index " + std::to_string(i)));
-        append_norm(vector_data);
     }
 
     return Ret(0);
@@ -225,8 +235,6 @@ Ret DataWriter::write(const InputReaderView& reader, const std::string& output_p
     }
 
     const uint32_t norm_flags = data_file_norm_flags_for_dist(dist_func);
-    const bool is_norms_section = norm_flags != 0u;
-    
     // Build DataFileHeader
     DataFileHeader hdr = make_data_header(
         stats.min_id,
@@ -260,21 +268,9 @@ Ret DataWriter::write(const InputReaderView& reader, const std::string& output_p
     CHECK(write_header_and_data_padding(f, hdr, "DataWriter"));
 
     const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr, stats.active_count);
-    std::vector<float> norms;
-    if (is_norms_section) {
-        norms.reserve(stats.active_count);
-    }
-    CHECK(write_vector_section(f, reader, hdr, dist_func, &norms));
+    CHECK(write_vector_section(f, reader, hdr, dist_func));
     CHECK(write_zero_padding(f, metadata_layout.vectors_padding,
-        "DataWriter: failed to write norms alignment padding"));
-
-#ifndef NDEBUG
-    assert(!is_norms_section || norms.size() == stats.active_count);
-#endif
-    CHECK(write_f32_array(f, norms,
-        "DataWriter: failed to write norms"));
-    CHECK(write_zero_padding(f, metadata_layout.ids_trailer_padding,
-        "DataWriter: failed to write id alignment padding"));
+        "DataWriter: failed to write ids alignment padding"));
 
     // Write compact id sections (active ids then deleted ids).
     CHECK(active_ids.write(f, "DataWriter: failed to write ids"));

--- a/src/core/storage/data_writer.cpp
+++ b/src/core/storage/data_writer.cpp
@@ -190,7 +190,7 @@ Ret DataWriter::exec_for_testing(const std::string& input_path, const std::strin
 
 // Converts a sorted text-or-binary input view into the binary on-disk data-file format.
 // It separates live ids from deletions, streams vectors into the aligned data
-// section, optionally persists norms, and then appends both id tables.
+// section, and then appends both id tables.
 Ret DataWriter::write(const InputReaderView& reader, const std::string& output_path, DistFunc dist_func) {
     const size_t count = reader.count();
     if (count == 0) {

--- a/src/core/storage/data_writer.cpp
+++ b/src/core/storage/data_writer.cpp
@@ -86,37 +86,18 @@ Ret write_vector_section(
         }
     };
 
-    if (binary_input) {
-        for (size_t i = 0; i < count; ++i) {
-            if (reader.is_no_data(i)) {
-                continue;
-            }
-
-            const uint8_t* vector_data = nullptr;
-            CHECK(reader.raw_data(i, &vector_data));
-            float norm_value = 0.0f;
-            float* norm_ptr = nullptr;
-            if (data_file_has_norms(hdr)) {
-                compute_norm(vector_data, &norm_value);
-                norm_ptr = &norm_value;
-            }
-            CHECK(write_data_record(
-                f,
-                vector_data,
-                record_layout,
-                norm_ptr,
-                "DataWriter: failed to write vector data at index " + std::to_string(i)));
-        }
-        return Ret(0);
-    }
-
     for (size_t i = 0; i < count; ++i) {
         if (reader.is_no_data(i)) {
             continue;
         }
 
-        CHECK(reader.data(i, buf.data(), buf.size()));
-        const uint8_t* vector_data = buf.data();
+        const uint8_t* vector_data = nullptr;
+        if (binary_input) {
+            CHECK(reader.raw_data(i, &vector_data));
+        } else {
+            CHECK(reader.data(i, buf.data(), buf.size()));
+            vector_data = buf.data();
+        }
         float norm_value = 0.0f;
         float* norm_ptr = nullptr;
         if (data_file_has_norms(hdr)) {

--- a/src/core/storage/utest_data_file_layout.cpp
+++ b/src/core/storage/utest_data_file_layout.cpp
@@ -153,7 +153,7 @@ TEST_F(DataFileLayoutTest, ComputeMetadataLayoutKeepsInlineNormsAndPlacesIdsAfte
         align_up<size_t>(static_cast<size_t>(hdr.data_offset) + layout.vectors_bytes, kDataRegionAlignment));
 }
 
-TEST_F(DataFileLayoutTest, SetDataHeaderLayoutZerosStandaloneNormSectionFields) {
+TEST_F(DataFileLayoutTest, SetDataHeaderLayoutKeepsLegacyStandaloneNormFieldsZeroed) {
     auto hdr = make_data_header(
         10, 20, 3, 1, DataType::f32, 8, data_file_norm_flags_for_dist(DistFunc::COS));
     ASSERT_EQ(0, set_data_header_layout(&hdr, 48, 16).code());

--- a/src/core/storage/utest_data_file_layout.cpp
+++ b/src/core/storage/utest_data_file_layout.cpp
@@ -62,7 +62,7 @@ TEST_F(DataFileLayoutTest, MakeDataHeaderSetsSquaredNormFlagWhenRequested) {
     EXPECT_EQ(kDataFileHasSquaredNorms, hdr.flags);
 }
 
-TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutF32Dim8MatchesIntendedV11StrideMath) {
+TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutF32Dim8MatchesIntendedStrideMath) {
     const auto dot_layout = compute_data_record_layout(DataType::f32, 8, false);
     EXPECT_EQ(8u * sizeof(float), dot_layout.vector_size);
     EXPECT_EQ(8u * sizeof(float), dot_layout.norm_offset);
@@ -79,7 +79,7 @@ TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutF32Dim8MatchesIntendedV11Strid
     EXPECT_EQ(cos_layout.stride, l2_layout.stride);
 }
 
-TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutF32Dim16MatchesIntendedV11StrideMath) {
+TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutF32Dim16MatchesIntendedStrideMath) {
     const auto dot_layout = compute_data_record_layout(DataType::f32, 16, false);
     EXPECT_EQ(16u * sizeof(float), dot_layout.vector_size);
     EXPECT_EQ(16u * sizeof(float), dot_layout.norm_offset);
@@ -134,8 +134,6 @@ TEST_F(DataFileLayoutTest, ComputeMetadataLayoutAlignsIdsTrailerOffsetToRegionBo
     const auto hdr = make_data_header(0, 0, 0, 0, DataType::f32, 5);
     const auto layout = compute_data_metadata_layout(hdr, 1);
     EXPECT_EQ(static_cast<size_t>(hdr.vector_stride), layout.vectors_bytes);
-    EXPECT_EQ(0u, layout.norms_offset);
-    EXPECT_EQ(0u, layout.norms_bytes);
     EXPECT_EQ(0u, layout.ids_trailer_offset % kDataRegionAlignment);
     EXPECT_EQ(layout.ids_trailer_offset - (static_cast<size_t>(hdr.data_offset) + layout.vectors_bytes),
         layout.vectors_padding);
@@ -146,19 +144,15 @@ TEST_F(DataFileLayoutTest, ComputeMetadataLayoutKeepsInlineNormsAndPlacesIdsAfte
     const auto hdr = make_data_header(
         0, 0, 0, 0, DataType::f32, 5, data_file_norm_flags_for_dist(DistFunc::COS));
     const auto layout = compute_data_metadata_layout(hdr, 3);
-    EXPECT_EQ(0u, layout.norms_offset);
-    EXPECT_EQ(0u, layout.norms_bytes);
     EXPECT_EQ(0u, layout.ids_trailer_offset % kDataRegionAlignment);
     EXPECT_EQ(layout.ids_trailer_offset,
         align_up<size_t>(static_cast<size_t>(hdr.data_offset) + layout.vectors_bytes, kDataRegionAlignment));
 }
 
-TEST_F(DataFileLayoutTest, SetDataHeaderLayoutKeepsLegacyStandaloneNormFieldsZeroed) {
+TEST_F(DataFileLayoutTest, SetDataHeaderLayoutComputesVectorAndIdsSections) {
     auto hdr = make_data_header(
         10, 20, 3, 1, DataType::f32, 8, data_file_norm_flags_for_dist(DistFunc::COS));
     ASSERT_EQ(0, set_data_header_layout(&hdr, 48, 16).code());
-    EXPECT_EQ(0u, hdr.norms_offset);
-    EXPECT_EQ(0u, hdr.norms_bytes);
     EXPECT_EQ(hdr.data_offset + static_cast<uint64_t>(hdr.count) * hdr.vector_stride, hdr.data_offset + hdr.vectors_bytes);
     EXPECT_EQ(compute_data_region_offset(static_cast<size_t>(hdr.data_offset) + hdr.vectors_bytes), hdr.ids_offset);
 }
@@ -227,7 +221,7 @@ TEST_F(DataFileLayoutTest, WriteDataRecordPadsToStrideWithoutNorms) {
 
     std::ifstream in(path_, std::ios::binary);
     std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    ASSERT_EQ(static_cast<size_t>(layout.stride), bytes.size());
+    ASSERT_EQ(layout.stride, bytes.size());
     for (size_t i = values.size() * sizeof(float); i < bytes.size(); ++i) {
         EXPECT_EQ(0u, bytes[i]);
     }
@@ -250,7 +244,7 @@ TEST_F(DataFileLayoutTest, WriteDataRecordStoresInlineNormAndPadding) {
 
     std::ifstream in(path_, std::ios::binary);
     std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    ASSERT_EQ(static_cast<size_t>(layout.stride), bytes.size());
+    ASSERT_EQ(layout.stride, bytes.size());
 
     float persisted_norm = 0.0f;
     std::memcpy(&persisted_norm, bytes.data() + layout.norm_offset, sizeof(persisted_norm));

--- a/src/core/storage/utest_data_file_layout.cpp
+++ b/src/core/storage/utest_data_file_layout.cpp
@@ -60,6 +60,74 @@ TEST_F(DataFileLayoutTest, MakeDataHeaderSetsSquaredNormFlagWhenRequested) {
     EXPECT_EQ(kDataFileHasSquaredNorms, hdr.flags);
 }
 
+TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutF32Dim8MatchesIntendedV11StrideMath) {
+    const auto dot_layout = compute_data_record_layout(DataType::f32, 8, false);
+    EXPECT_EQ(8u * sizeof(float), dot_layout.vector_size);
+    EXPECT_EQ(8u * sizeof(float), dot_layout.norm_offset);
+    EXPECT_EQ(32u, dot_layout.stride);
+
+    const auto cos_layout = compute_data_record_layout(DataType::f32, 8, true);
+    EXPECT_EQ(8u * sizeof(float), cos_layout.vector_size);
+    EXPECT_EQ(8u * sizeof(float), cos_layout.norm_offset);
+    EXPECT_EQ(64u, cos_layout.stride);
+
+    const auto l2_layout = compute_data_record_layout(DataType::f32, 8, true);
+    EXPECT_EQ(cos_layout.vector_size, l2_layout.vector_size);
+    EXPECT_EQ(cos_layout.norm_offset, l2_layout.norm_offset);
+    EXPECT_EQ(cos_layout.stride, l2_layout.stride);
+}
+
+TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutF32Dim16MatchesIntendedV11StrideMath) {
+    const auto dot_layout = compute_data_record_layout(DataType::f32, 16, false);
+    EXPECT_EQ(16u * sizeof(float), dot_layout.vector_size);
+    EXPECT_EQ(16u * sizeof(float), dot_layout.norm_offset);
+    EXPECT_EQ(64u, dot_layout.stride);
+
+    const auto cos_layout = compute_data_record_layout(DataType::f32, 16, true);
+    EXPECT_EQ(16u * sizeof(float), cos_layout.vector_size);
+    EXPECT_EQ(16u * sizeof(float), cos_layout.norm_offset);
+    EXPECT_EQ(96u, cos_layout.stride);
+
+    const auto l2_layout = compute_data_record_layout(DataType::f32, 16, true);
+    EXPECT_EQ(cos_layout.vector_size, l2_layout.vector_size);
+    EXPECT_EQ(cos_layout.norm_offset, l2_layout.norm_offset);
+    EXPECT_EQ(cos_layout.stride, l2_layout.stride);
+}
+
+TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutNonAlignedVectorShapeKeepsNormInline) {
+    const auto dot_layout = compute_data_record_layout(DataType::f32, 5, false);
+    EXPECT_EQ(5u * sizeof(float), dot_layout.vector_size);
+    EXPECT_EQ(5u * sizeof(float), dot_layout.norm_offset);
+    EXPECT_EQ(32u, dot_layout.stride);
+
+    const auto cos_layout = compute_data_record_layout(DataType::f32, 5, true);
+    EXPECT_EQ(5u * sizeof(float), cos_layout.vector_size);
+    EXPECT_EQ(5u * sizeof(float), cos_layout.norm_offset);
+    EXPECT_EQ(32u, cos_layout.stride);
+
+    const auto l2_layout = compute_data_record_layout(DataType::f32, 5, true);
+    EXPECT_EQ(cos_layout.vector_size, l2_layout.vector_size);
+    EXPECT_EQ(cos_layout.norm_offset, l2_layout.norm_offset);
+    EXPECT_EQ(cos_layout.stride, l2_layout.stride);
+}
+
+TEST_F(DataFileLayoutTest, ComputeDataRecordLayoutAlignsOddSizedI16NormSlot) {
+    const auto dot_layout = compute_data_record_layout(DataType::i16, 5, false);
+    EXPECT_EQ(10u, dot_layout.vector_size);
+    EXPECT_EQ(12u, dot_layout.norm_offset);
+    EXPECT_EQ(32u, dot_layout.stride);
+
+    const auto cos_layout = compute_data_record_layout(DataType::i16, 5, true);
+    EXPECT_EQ(10u, cos_layout.vector_size);
+    EXPECT_EQ(12u, cos_layout.norm_offset);
+    EXPECT_EQ(32u, cos_layout.stride);
+
+    const auto l2_layout = compute_data_record_layout(DataType::i16, 5, true);
+    EXPECT_EQ(cos_layout.vector_size, l2_layout.vector_size);
+    EXPECT_EQ(cos_layout.norm_offset, l2_layout.norm_offset);
+    EXPECT_EQ(cos_layout.stride, l2_layout.stride);
+}
+
 TEST_F(DataFileLayoutTest, ComputeMetadataLayoutAlignsIdsTrailerOffsetToRegionBoundary) {
     const auto hdr = make_data_header(0, 0, 0, 0, DataType::f32, 5);
     const auto layout = compute_data_metadata_layout(hdr, 1);

--- a/src/core/storage/utest_data_file_layout.cpp
+++ b/src/core/storage/utest_data_file_layout.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <string>
 #include <unistd.h>
@@ -28,6 +29,7 @@ protected:
 
 TEST_F(DataFileLayoutTest, MakeDataHeaderSetsExpectedFields) {
     const auto hdr = make_data_header(10, 20, 7, 2, DataType::f32, 64);
+    const auto record_layout = compute_data_record_layout(DataType::f32, 64, false);
     EXPECT_EQ(kMagic, hdr.base.magic);
     EXPECT_EQ(static_cast<uint16_t>(FileType::Data), hdr.base.kind);
     EXPECT_EQ(kVersion, hdr.base.version);
@@ -39,7 +41,7 @@ TEST_F(DataFileLayoutTest, MakeDataHeaderSetsExpectedFields) {
     EXPECT_EQ(64u, hdr.dim);
     EXPECT_EQ(0u, hdr.data_offset % kDataRegionAlignment);
     EXPECT_GE(hdr.data_offset, sizeof(DataFileHeader));
-    EXPECT_EQ(compute_vector_stride(64u * sizeof(float)), hdr.vector_stride);
+    EXPECT_EQ(record_layout.stride, hdr.vector_stride);
     EXPECT_EQ(0u, hdr.vector_stride % kDataAlignment);
     EXPECT_FALSE(data_file_has_norms(hdr));
 }
@@ -132,22 +134,33 @@ TEST_F(DataFileLayoutTest, ComputeMetadataLayoutAlignsIdsTrailerOffsetToRegionBo
     const auto hdr = make_data_header(0, 0, 0, 0, DataType::f32, 5);
     const auto layout = compute_data_metadata_layout(hdr, 1);
     EXPECT_EQ(static_cast<size_t>(hdr.vector_stride), layout.vectors_bytes);
+    EXPECT_EQ(0u, layout.norms_offset);
+    EXPECT_EQ(0u, layout.norms_bytes);
     EXPECT_EQ(0u, layout.ids_trailer_offset % kDataRegionAlignment);
     EXPECT_EQ(layout.ids_trailer_offset - (static_cast<size_t>(hdr.data_offset) + layout.vectors_bytes),
-        layout.ids_trailer_padding);
+        layout.vectors_padding);
+    EXPECT_EQ(0u, layout.ids_trailer_padding);
 }
 
-TEST_F(DataFileLayoutTest, ComputeMetadataLayoutPlacesCosineSectionBeforeIdsTrailer) {
+TEST_F(DataFileLayoutTest, ComputeMetadataLayoutKeepsInlineNormsAndPlacesIdsAfterVectors) {
     const auto hdr = make_data_header(
         0, 0, 0, 0, DataType::f32, 5, data_file_norm_flags_for_dist(DistFunc::COS));
     const auto layout = compute_data_metadata_layout(hdr, 3);
-    EXPECT_EQ(0u, layout.norms_offset % kDataRegionAlignment);
-    EXPECT_EQ(layout.norms_offset,
-        align_up<size_t>(static_cast<size_t>(hdr.data_offset) + layout.vectors_bytes, kDataRegionAlignment));
-    EXPECT_EQ(3u * sizeof(float), layout.norms_bytes);
+    EXPECT_EQ(0u, layout.norms_offset);
+    EXPECT_EQ(0u, layout.norms_bytes);
     EXPECT_EQ(0u, layout.ids_trailer_offset % kDataRegionAlignment);
     EXPECT_EQ(layout.ids_trailer_offset,
-        align_up<size_t>(layout.norms_offset + layout.norms_bytes, kDataRegionAlignment));
+        align_up<size_t>(static_cast<size_t>(hdr.data_offset) + layout.vectors_bytes, kDataRegionAlignment));
+}
+
+TEST_F(DataFileLayoutTest, SetDataHeaderLayoutZerosStandaloneNormSectionFields) {
+    auto hdr = make_data_header(
+        10, 20, 3, 1, DataType::f32, 8, data_file_norm_flags_for_dist(DistFunc::COS));
+    ASSERT_EQ(0, set_data_header_layout(&hdr, 48, 16).code());
+    EXPECT_EQ(0u, hdr.norms_offset);
+    EXPECT_EQ(0u, hdr.norms_bytes);
+    EXPECT_EQ(hdr.data_offset + static_cast<uint64_t>(hdr.count) * hdr.vector_stride, hdr.data_offset + hdr.vectors_bytes);
+    EXPECT_EQ(compute_data_region_offset(static_cast<size_t>(hdr.data_offset) + hdr.vectors_bytes), hdr.ids_offset);
 }
 
 TEST_F(DataFileLayoutTest, WriteZeroPaddingWritesRequestedZeros) {
@@ -198,20 +211,55 @@ TEST_F(DataFileLayoutTest, RewriteHeaderOverwritesExistingHeader) {
     EXPECT_EQ(100u, read.min_id);
 }
 
-TEST_F(DataFileLayoutTest, WriteVectorRecordPadsToStride) {
-    const auto hdr = make_data_header(1, 1, 1, 0, DataType::f32, 5);
+TEST_F(DataFileLayoutTest, WriteDataRecordPadsToStrideWithoutNorms) {
+    const auto layout = compute_data_record_layout(DataType::f32, 5, false);
     const std::vector<float> values = {1.f, 2.f, 3.f, 4.f, 5.f};
 
     FILE* f = fopen(path_.c_str(), "wb");
     ASSERT_NE(nullptr, f);
-    ASSERT_EQ(0, write_vector_record(f, reinterpret_cast<const uint8_t*>(values.data()),
-        values.size() * sizeof(float), hdr.vector_stride, "ctx").code());
+    ASSERT_EQ(0, write_data_record(
+        f,
+        reinterpret_cast<const uint8_t*>(values.data()),
+        layout,
+        nullptr,
+        "ctx").code());
     fclose(f);
 
     std::ifstream in(path_, std::ios::binary);
     std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    ASSERT_EQ(static_cast<size_t>(hdr.vector_stride), bytes.size());
+    ASSERT_EQ(static_cast<size_t>(layout.stride), bytes.size());
     for (size_t i = values.size() * sizeof(float); i < bytes.size(); ++i) {
+        EXPECT_EQ(0u, bytes[i]);
+    }
+}
+
+TEST_F(DataFileLayoutTest, WriteDataRecordStoresInlineNormAndPadding) {
+    const auto layout = compute_data_record_layout(DataType::i16, 5, true);
+    const std::vector<int16_t> values = {1, 2, 3, 4, 5};
+    const float norm = 42.5f;
+
+    FILE* f = fopen(path_.c_str(), "wb");
+    ASSERT_NE(nullptr, f);
+    ASSERT_EQ(0, write_data_record(
+        f,
+        reinterpret_cast<const uint8_t*>(values.data()),
+        layout,
+        &norm,
+        "ctx").code());
+    fclose(f);
+
+    std::ifstream in(path_, std::ios::binary);
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    ASSERT_EQ(static_cast<size_t>(layout.stride), bytes.size());
+
+    float persisted_norm = 0.0f;
+    std::memcpy(&persisted_norm, bytes.data() + layout.norm_offset, sizeof(persisted_norm));
+    EXPECT_FLOAT_EQ(norm, persisted_norm);
+
+    for (size_t i = layout.vector_size; i < layout.norm_offset; ++i) {
+        EXPECT_EQ(0u, bytes[i]);
+    }
+    for (size_t i = layout.norm_offset + sizeof(float); i < bytes.size(); ++i) {
         EXPECT_EQ(0u, bytes[i]);
     }
 }

--- a/src/core/storage/utest_data_merger.cpp
+++ b/src/core/storage/utest_data_merger.cpp
@@ -599,7 +599,7 @@ TEST_F(DataMergerTest, MergeDataFileFromInputViewWithSpaceSeparatedTextParsesAnd
     EXPECT_FLOAT_EQ(5.0f, first_f32(out_reader, 5));
 }
 
-TEST_F(DataMergerTest, MergeDataFilePreservesCosineValuesSection) {
+TEST_F(DataMergerTest, MergeDataFilePreservesInlineCosineValues) {
     const std::string source_path = p("source_cos.data");
     const std::string updater_path = p("updater_cos.data");
     const std::string out_path = p("merged_cos.data");
@@ -1218,7 +1218,7 @@ TEST_F(DataMergerTest, MergeDeltaFileFromInputViewRejectsIncompatibleType) {
     EXPECT_FALSE(fs::exists(out_path));
 }
 
-TEST_F(DataMergerTest, MergeDeltaFilePreservesCosineValuesSection) {
+TEST_F(DataMergerTest, MergeDeltaFilePreservesInlineCosineValues) {
     const std::string source_path = p("source_cos.delta");
     const std::string updater_path = p("updater_cos.delta");
     const std::string out_path = p("merged_cos.delta");

--- a/src/core/storage/utest_data_merger.cpp
+++ b/src/core/storage/utest_data_merger.cpp
@@ -237,8 +237,7 @@ protected:
 
     void expect_inline_norm_layout(const std::string& path) {
         const DataFileHeader hdr = read_header(path);
-        EXPECT_EQ(0u, hdr.norms_offset);
-        EXPECT_EQ(0u, hdr.norms_bytes);
+        EXPECT_TRUE(data_file_has_norms(hdr));
     }
 
     CompactIdsExtEncoding read_active_ids_encoding(const std::string& path) {

--- a/src/core/storage/utest_data_merger.cpp
+++ b/src/core/storage/utest_data_merger.cpp
@@ -212,6 +212,12 @@ protected:
         return hdr;
     }
 
+    void expect_inline_norm_layout(const std::string& path) {
+        const DataFileHeader hdr = read_header(path);
+        EXPECT_EQ(0u, hdr.norms_offset);
+        EXPECT_EQ(0u, hdr.norms_bytes);
+    }
+
     CompactIdsExtEncoding read_active_ids_encoding(const std::string& path) {
         const DataFileHeader hdr = read_header(path);
         const size_t ids_offset = compute_data_metadata_layout(hdr, hdr.count).ids_trailer_offset;
@@ -343,6 +349,7 @@ TEST_F(DataMergerTest, MergeDataFileFromInputViewMergesAndPreservesCosineValues)
     ASSERT_EQ(0, merger.merge_data_file(source_reader, view, out_path, DistFunc::COS).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_EQ(4u, out_reader.count());
     ASSERT_TRUE(out_reader.has_norms());
     EXPECT_EQ(nullptr, out_reader.get(1));
@@ -408,6 +415,7 @@ TEST_F(DataMergerTest, MergeDataFileFromInputViewPreservesL2Norms) {
     ASSERT_EQ(0, merger.merge_data_file(source_reader, view, out_path, DistFunc::L2).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_EQ(4u, out_reader.count());
     ASSERT_TRUE(out_reader.has_norms());
     EXPECT_EQ(nullptr, out_reader.get(1));
@@ -442,6 +450,7 @@ TEST_F(DataMergerTest, MergeDataFileFromInputViewAddsL2NormsWhenSourceLacksThem)
     ASSERT_EQ(0, merger.merge_data_file(source_reader, view, out_path, DistFunc::L2).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_TRUE(out_reader.has_norms());
     ASSERT_TRUE(data_file_has_squared_norms(read_header(out_path)));
     EXPECT_FLOAT_EQ(36.0f, out_reader.get_norm(0));
@@ -470,6 +479,7 @@ TEST_F(DataMergerTest, MergeDataFileFromInputViewRewritesCosineNormsToL2) {
     ASSERT_EQ(0, merger.merge_data_file(source_reader, view, out_path, DistFunc::L2).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_TRUE(out_reader.has_norms());
     ASSERT_TRUE(data_file_has_squared_norms(read_header(out_path)));
     EXPECT_FLOAT_EQ(36.0f, out_reader.get_norm(0));
@@ -1044,6 +1054,7 @@ TEST_F(DataMergerTest, MergeDeltaFileFromInputViewPreservesCosineValues) {
     ASSERT_EQ(0, merger.merge_delta_file(source_reader, view, out_path, DistFunc::COS).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_TRUE(out_reader.has_norms());
     ASSERT_EQ(3u, out_reader.count());
     EXPECT_NEAR(1.0 / (2.0 * std::sqrt(4.0)), static_cast<double>(out_reader.get_norm(0)), 1e-6);
@@ -1111,6 +1122,7 @@ TEST_F(DataMergerTest, MergeDeltaFileFromInputViewPreservesL2Norms) {
     ASSERT_EQ(0, merger.merge_delta_file(source_reader, view, out_path, DistFunc::L2).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_TRUE(out_reader.has_norms());
     ASSERT_EQ(3u, out_reader.count());
     EXPECT_FLOAT_EQ(16.0f, out_reader.get_norm(0));
@@ -1149,6 +1161,7 @@ TEST_F(DataMergerTest, MergeDeltaFileFromInputViewAddsCosineNormsWhenSourceLacks
     ASSERT_EQ(0, merger.merge_delta_file(source_reader, view, out_path, DistFunc::COS).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_TRUE(out_reader.has_norms());
     ASSERT_TRUE(data_file_has_cosine_inv_norms(read_header(out_path)));
     ASSERT_EQ(3u, out_reader.count());
@@ -1196,6 +1209,7 @@ TEST_F(DataMergerTest, MergeDeltaFilePreservesCosineValuesSection) {
     ASSERT_EQ(0, merger.merge_delta_file(source_reader, updater_reader, out_path).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_TRUE(out_reader.has_norms());
     ASSERT_EQ(3u, out_reader.count());
     EXPECT_NEAR(1.0 / (2.0 * std::sqrt(4.0)), static_cast<double>(out_reader.get_norm(0)), 1e-6);

--- a/src/core/storage/utest_data_merger.cpp
+++ b/src/core/storage/utest_data_merger.cpp
@@ -116,7 +116,7 @@ protected:
                 }
                 norm_ptr = &norm;
             }
-            ASSERT_EQ(0, write_vector_record_with_optional_norm(
+            ASSERT_EQ(0, write_data_record(
                 f,
                 reinterpret_cast<const uint8_t*>(vec.data()),
                 record_layout,
@@ -144,7 +144,9 @@ protected:
                         FileType kind,
                         const std::vector<std::pair<uint64_t, int16_t>>& active,
                         const std::vector<uint64_t>& deleted,
-                        uint16_t dim = kDim) {
+                        uint16_t dim = kDim,
+                        bool has_norms = false,
+                        DistFunc stored_norm_dist_func = DistFunc::COS) {
         std::vector<uint64_t> active_ids;
         active_ids.reserve(active.size());
         for (const auto& item : active) {
@@ -159,7 +161,8 @@ protected:
             static_cast<uint32_t>(active.size()),
             static_cast<uint32_t>(deleted.size()),
             DataType::i16,
-            dim);
+            dim,
+            has_norms ? data_file_norm_flags_for_dist(stored_norm_dist_func) : 0u);
         hdr.base.kind = static_cast<uint16_t>(kind);
         CompactIds compact_active_ids;
         ASSERT_EQ(0, compact_active_ids.init(active_ids).code());
@@ -178,10 +181,30 @@ protected:
             ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
         }
 
+        const DataRecordLayout record_layout =
+            compute_data_record_layout(DataType::i16, dim, has_norms);
         for (const auto& item : active) {
             std::vector<int16_t> vec(dim, item.second);
-            ASSERT_EQ(0, write_vector_record(f, reinterpret_cast<const uint8_t*>(vec.data()),
-                vec.size() * sizeof(int16_t), hdr.vector_stride, "DataMergerTest::write_i16_file").code());
+            float norm = 0.0f;
+            float* norm_ptr = nullptr;
+            if (has_norms) {
+                if (stored_norm_dist_func == DistFunc::COS) {
+                    norm = compute_cosine_inverse_norm(
+                        reinterpret_cast<const uint8_t*>(vec.data()), DataType::i16, dim);
+                } else if (stored_norm_dist_func == DistFunc::L2) {
+                    norm = compute_squared_norm(
+                        reinterpret_cast<const uint8_t*>(vec.data()), DataType::i16, dim);
+                } else {
+                    FAIL() << "write_i16_file: invalid stored norm distance function";
+                }
+                norm_ptr = &norm;
+            }
+            ASSERT_EQ(0, write_data_record(
+                f,
+                reinterpret_cast<const uint8_t*>(vec.data()),
+                record_layout,
+                norm_ptr,
+                "DataMergerTest::write_i16_file").code());
         }
         const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr, active.size());
         const size_t ids_pad_size = metadata_layout.vectors_padding;
@@ -743,6 +766,21 @@ TEST_F(DataMergerTest, MergeDataFileRejectsUpdatedIdAlsoDeletedAndCleansOutput) 
     const auto ret = merger.merge_data_file(source_reader, updater_reader, out_path);
     EXPECT_NE(0, ret.code());
     EXPECT_FALSE(fs::exists(out_path));
+}
+
+TEST_F(DataMergerTest, WriteI16FileSupportsInlineNorms) {
+    const std::string path = p("i16_norms.data");
+
+    write_i16_file(path, FileType::Data, {{7, 3}, {8, 4}}, {}, 4, true, DistFunc::L2);
+
+    DataReader reader;
+    ASSERT_EQ(0, reader.init(path).code());
+    ASSERT_TRUE(reader.has_norms());
+    EXPECT_TRUE(reader.has_matching_stored_norms(DistFunc::L2));
+    EXPECT_FALSE(reader.has_matching_stored_norms(DistFunc::COS));
+    EXPECT_GT(reader.stride(), reader.size());
+    EXPECT_FLOAT_EQ(36.0f, reader.get_norm(0));
+    EXPECT_FLOAT_EQ(64.0f, reader.get_norm(1));
 }
 
 TEST_F(DataMergerTest, MergeDataFileFromInputViewRejectsIncompatibleDim) {

--- a/src/core/storage/utest_data_merger.cpp
+++ b/src/core/storage/utest_data_merger.cpp
@@ -615,10 +615,35 @@ TEST_F(DataMergerTest, MergeDataFilePreservesCosineValuesSection) {
     ASSERT_EQ(0, merger.merge_data_file(source_reader, updater_reader, out_path).code());
 
     ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
     ASSERT_TRUE(out_reader.has_norms());
     EXPECT_NEAR(1.0 / (3.0 * std::sqrt(4.0)), static_cast<double>(out_reader.get_norm(0)), 1e-6);
     EXPECT_NEAR(1.0 / (5.0 * std::sqrt(4.0)), static_cast<double>(out_reader.get_norm(1)), 1e-6);
     EXPECT_NEAR(1.0 / (8.0 * std::sqrt(4.0)), static_cast<double>(out_reader.get_norm(2)), 1e-6);
+}
+
+TEST_F(DataMergerTest, MergeDataFilePreservesL2NormsAndInlineLayout) {
+    const std::string source_path = p("source_l2.data");
+    const std::string updater_path = p("updater_l2.data");
+    const std::string out_path = p("merged_l2.data");
+
+    write_f32_file(source_path, FileType::Data, {{1, 3.0f}, {3, 4.0f}}, {}, kDim, true, DistFunc::L2);
+    write_f32_file(updater_path, FileType::Data, {{2, 5.0f}, {3, 8.0f}}, {}, kDim, true, DistFunc::L2);
+
+    DataReader source_reader, updater_reader, out_reader;
+    ASSERT_EQ(0, source_reader.init(source_path).code());
+    ASSERT_EQ(0, updater_reader.init(updater_path).code());
+
+    DataMerger merger;
+    ASSERT_EQ(0, merger.merge_data_file(source_reader, updater_reader, out_path).code());
+
+    ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
+    ASSERT_TRUE(out_reader.has_norms());
+    ASSERT_TRUE(data_file_has_squared_norms(read_header(out_path)));
+    EXPECT_FLOAT_EQ(36.0f, out_reader.get_norm(0));
+    EXPECT_FLOAT_EQ(100.0f, out_reader.get_norm(1));
+    EXPECT_FLOAT_EQ(256.0f, out_reader.get_norm(2));
 }
 
 TEST_F(DataMergerTest, MergeDataFileAllDeletedProducesEmptyFile) {
@@ -1215,6 +1240,39 @@ TEST_F(DataMergerTest, MergeDeltaFilePreservesCosineValuesSection) {
     EXPECT_NEAR(1.0 / (2.0 * std::sqrt(4.0)), static_cast<double>(out_reader.get_norm(0)), 1e-6);
     EXPECT_NEAR(1.0 / (3.0 * std::sqrt(4.0)), static_cast<double>(out_reader.get_norm(1)), 1e-6);
     EXPECT_NEAR(1.0 / (8.0 * std::sqrt(4.0)), static_cast<double>(out_reader.get_norm(2)), 1e-6);
+    EXPECT_EQ((std::vector<uint64_t>{1u, 5u}),
+        [&]() {
+            std::vector<uint64_t> ids;
+            for (size_t i = 0; i < out_reader.deleted_count(); ++i) {
+                ids.push_back(out_reader.deleted_id(i));
+            }
+            return ids;
+        }());
+}
+
+TEST_F(DataMergerTest, MergeDeltaFilePreservesL2NormsAndInlineLayout) {
+    const std::string source_path = p("source_l2.delta");
+    const std::string updater_path = p("updater_l2.delta");
+    const std::string out_path = p("merged_l2.delta");
+
+    write_f32_file(source_path, FileType::Data, {{2, 2.0f}, {4, 4.0f}}, {1}, kDim, true, DistFunc::L2);
+    write_f32_file(updater_path, FileType::Data, {{3, 3.0f}, {4, 8.0f}}, {5}, kDim, true, DistFunc::L2);
+
+    DataReader source_reader, updater_reader, out_reader;
+    ASSERT_EQ(0, source_reader.init(source_path).code());
+    ASSERT_EQ(0, updater_reader.init(updater_path).code());
+
+    DataMerger merger;
+    ASSERT_EQ(0, merger.merge_delta_file(source_reader, updater_reader, out_path).code());
+
+    ASSERT_EQ(0, out_reader.init(out_path).code());
+    expect_inline_norm_layout(out_path);
+    ASSERT_TRUE(out_reader.has_norms());
+    ASSERT_TRUE(data_file_has_squared_norms(read_header(out_path)));
+    ASSERT_EQ(3u, out_reader.count());
+    EXPECT_FLOAT_EQ(16.0f, out_reader.get_norm(0));
+    EXPECT_FLOAT_EQ(36.0f, out_reader.get_norm(1));
+    EXPECT_FLOAT_EQ(256.0f, out_reader.get_norm(2));
     EXPECT_EQ((std::vector<uint64_t>{1u, 5u}),
         [&]() {
             std::vector<uint64_t> ids;

--- a/src/core/storage/utest_data_merger.cpp
+++ b/src/core/storage/utest_data_merger.cpp
@@ -100,34 +100,31 @@ protected:
 
         for (const auto& item : active) {
             std::vector<float> vec(dim, item.second);
-            ASSERT_EQ(0, write_vector_record(f, reinterpret_cast<const uint8_t*>(vec.data()),
-                vec.size() * sizeof(float), hdr.vector_stride, "DataMergerTest::write_f32_file").code());
-        }
-        if (has_norms) {
-            std::vector<float> norms;
-            norms.reserve(active.size());
-            for (const auto& item : active) {
-                std::vector<float> vec(dim, item.second);
+            const DataRecordLayout record_layout =
+                compute_data_record_layout(DataType::f32, dim, has_norms);
+            float norm = 0.0f;
+            float* norm_ptr = nullptr;
+            if (has_norms) {
                 if (stored_norm_dist_func == DistFunc::COS) {
-                    norms.push_back(compute_cosine_inverse_norm(
-                        reinterpret_cast<const uint8_t*>(vec.data()), DataType::f32, dim));
+                    norm = compute_cosine_inverse_norm(
+                        reinterpret_cast<const uint8_t*>(vec.data()), DataType::f32, dim);
                 } else if (stored_norm_dist_func == DistFunc::L2) {
-                    norms.push_back(compute_squared_norm(
-                        reinterpret_cast<const uint8_t*>(vec.data()), DataType::f32, dim));
+                    norm = compute_squared_norm(
+                        reinterpret_cast<const uint8_t*>(vec.data()), DataType::f32, dim);
                 } else {
                     FAIL() << "write_f32_file: invalid stored norm distance function";
                 }
+                norm_ptr = &norm;
             }
-            const size_t norms_pad_size = compute_data_metadata_layout(hdr, active.size()).vectors_padding;
-            if (norms_pad_size > 0) {
-                std::vector<uint8_t> pad(norms_pad_size, 0);
-                ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
-            }
-            ASSERT_EQ(0, write_f32_array(f, norms,
-                "DataMergerTest::write_f32_file cosine").code());
+            ASSERT_EQ(0, write_vector_record_with_optional_norm(
+                f,
+                reinterpret_cast<const uint8_t*>(vec.data()),
+                record_layout,
+                norm_ptr,
+                "DataMergerTest::write_f32_file").code());
         }
         const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr, active.size());
-        const size_t ids_pad_size = metadata_layout.ids_trailer_padding;
+        const size_t ids_pad_size = metadata_layout.vectors_padding;
         if (ids_pad_size > 0) {
             std::vector<uint8_t> pad(ids_pad_size, 0);
             ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
@@ -187,7 +184,7 @@ protected:
                 vec.size() * sizeof(int16_t), hdr.vector_stride, "DataMergerTest::write_i16_file").code());
         }
         const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr, active.size());
-        const size_t ids_pad_size = metadata_layout.ids_trailer_padding;
+        const size_t ids_pad_size = metadata_layout.vectors_padding;
         if (ids_pad_size > 0) {
             std::vector<uint8_t> pad(ids_pad_size, 0);
             ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));

--- a/src/core/storage/utest_data_reader.cpp
+++ b/src/core/storage/utest_data_reader.cpp
@@ -296,6 +296,26 @@ TEST_F(DataReaderTest, FailsWhenInlineNormDoesNotFitStride) {
     EXPECT_NE(std::string::npos, ret.message().find("invalid inline norm layout"));
 }
 
+TEST_F(DataReaderTest, FailsWhenV11DeclaresSeparateNormsSection) {
+    generate(2, 0, DataType::f32, 4);
+
+    FILE* f = fopen(data_path_.c_str(), "r+b");
+    ASSERT_NE(nullptr, f);
+    DataFileHeader hdr{};
+    ASSERT_EQ(1u, fread(&hdr, sizeof(hdr), 1, f));
+    hdr.flags = kDataFileHasCosineInvNorms;
+    hdr.norms_offset = hdr.data_offset;
+    hdr.norms_bytes = sizeof(float) * hdr.count;
+    rewind(f);
+    ASSERT_EQ(1u, fwrite(&hdr, sizeof(hdr), 1, f));
+    fclose(f);
+
+    DataReader r;
+    const Ret ret = r.init(data_path_);
+    EXPECT_NE(0, ret.code());
+    EXPECT_NE(std::string::npos, ret.message().find("must not declare a separate norms section"));
+}
+
 TEST_F(DataReaderTest, FailsOnLegacyRawIdsTrailer) {
     const std::vector<std::vector<uint8_t>> vecs = {
         std::vector<uint8_t>(4 * sizeof(float), 0),

--- a/src/core/storage/utest_data_reader.cpp
+++ b/src/core/storage/utest_data_reader.cpp
@@ -590,6 +590,28 @@ TEST_F(DataReaderTest, AtReturnsNullForHiddenVector) {
     EXPECT_NE(nullptr, r.at(2));
 }
 
+TEST_F(DataReaderTest, GetNormThrowsForHiddenVector) {
+    GeneratorConfig cfg{PatternType::Sequential, 3, 0, DataType::f32, 4, 1000};
+    generate_input_file(input_path_, cfg);
+    std::ofstream delta(delta_input_path_);
+    ASSERT_TRUE(delta.is_open());
+    delta << "f32,4\n"
+          << "1 : [ 11.0, 11.0, 11.0, 11.0 ]\n";
+    delta.close();
+
+    DataWriter w;
+    ASSERT_EQ(0, w.exec_for_testing(input_path_, data_path_, 0, 0, DistFunc::COS).code());
+    ASSERT_EQ(0, w.exec_for_testing(delta_input_path_, delta_path_, 0, 0, DistFunc::COS).code());
+
+    DataReader r;
+    ASSERT_EQ(0, r.init(data_path_, make_delta_reader()).code());
+    ASSERT_TRUE(r.has_norms());
+
+    EXPECT_NEAR(1.0 / std::sqrt(4.0 * 0.1 * 0.1), static_cast<double>(r.get_norm(0)), 1e-6);
+    EXPECT_THROW(static_cast<void>(r.get_norm(1)), std::logic_error);
+    EXPECT_NEAR(1.0 / std::sqrt(4.0 * 2.1 * 2.1), static_cast<double>(r.get_norm(2)), 1e-6);
+}
+
 TEST_F(DataReaderTest, AtF32VectorDataIsCorrect) {
     const size_t count = 4, min_id = 10, dim = 4;
     generate(count, min_id, DataType::f32, dim);

--- a/src/core/storage/utest_data_reader.cpp
+++ b/src/core/storage/utest_data_reader.cpp
@@ -502,6 +502,8 @@ TEST_F(DataReaderTest, ReadsCosineValuesFromInlineRecords) {
     auto it = r.base_begin();
     ASSERT_FALSE(it.eof());
     EXPECT_NEAR(static_cast<double>(r.get_norm(0)), static_cast<double>(it.get_norm()), 1e-6);
+    EXPECT_NEAR(static_cast<double>(r.get_norm(0)),
+        static_cast<double>(r.get_norm_from_record_unchecked(it.data())), 1e-6);
 }
 
 TEST_F(DataReaderTest, ReadsL2NormValuesFromInlineRecords) {

--- a/src/core/storage/utest_data_reader.cpp
+++ b/src/core/storage/utest_data_reader.cpp
@@ -313,26 +313,6 @@ TEST_F(DataReaderTest, FailsWhenInlineNormDoesNotFitStride) {
     EXPECT_NE(std::string::npos, ret.message().find("invalid inline norm layout"));
 }
 
-TEST_F(DataReaderTest, FailsWhenV11DeclaresSeparateNormsSection) {
-    generate(2, 0, DataType::f32, 4);
-
-    FILE* f = fopen(data_path_.c_str(), "r+b");
-    ASSERT_NE(nullptr, f);
-    DataFileHeader hdr{};
-    ASSERT_EQ(1u, fread(&hdr, sizeof(hdr), 1, f));
-    hdr.flags = kDataFileHasCosineInvNorms;
-    hdr.norms_offset = hdr.data_offset;
-    hdr.norms_bytes = sizeof(float) * hdr.count;
-    rewind(f);
-    ASSERT_EQ(1u, fwrite(&hdr, sizeof(hdr), 1, f));
-    fclose(f);
-
-    DataReader r;
-    const Ret ret = r.init(data_path_);
-    EXPECT_NE(0, ret.code());
-    EXPECT_NE(std::string::npos, ret.message().find("must not declare a separate norms section"));
-}
-
 TEST_F(DataReaderTest, FailsOnLegacyRawIdsTrailer) {
     const std::vector<std::vector<uint8_t>> vecs = {
         std::vector<uint8_t>(4 * sizeof(float), 0),

--- a/src/core/storage/utest_data_reader.cpp
+++ b/src/core/storage/utest_data_reader.cpp
@@ -145,7 +145,7 @@ protected:
             ASSERT_EQ(0, write_vector_record(f, v.data(), v.size(), hdr.vector_stride, "DataReaderTest::write_raw").code());
         }
         const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr, vecs.size());
-        const size_t ids_pad_size = metadata_layout.ids_trailer_padding;
+        const size_t ids_pad_size = metadata_layout.vectors_padding;
         if (ids_pad_size > 0) {
             std::vector<uint8_t> pad(ids_pad_size, 0);
             fwrite(pad.data(), 1, pad.size(), f);
@@ -185,8 +185,8 @@ protected:
                       "DataReaderTest::write_raw_with_legacy_id_arrays").code());
         }
         const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr, vecs.size());
-        if (metadata_layout.ids_trailer_padding > 0) {
-            std::vector<uint8_t> pad(metadata_layout.ids_trailer_padding, 0);
+        if (metadata_layout.vectors_padding > 0) {
+            std::vector<uint8_t> pad(metadata_layout.vectors_padding, 0);
             ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
         }
         // Intentionally write legacy raw uint64 arrays to ensure hard cutover rejects them.
@@ -275,6 +275,25 @@ TEST_F(DataReaderTest, FailsOnInvalidCombinedNormFlags) {
     const Ret ret = r.init(data_path_);
     EXPECT_NE(0, ret.code());
     EXPECT_NE(std::string::npos, ret.message().find("invalid stored norm flags"));
+}
+
+TEST_F(DataReaderTest, FailsWhenInlineNormDoesNotFitStride) {
+    generate(2, 0, DataType::f32, 8);
+
+    FILE* f = fopen(data_path_.c_str(), "r+b");
+    ASSERT_NE(nullptr, f);
+    DataFileHeader hdr{};
+    ASSERT_EQ(1u, fread(&hdr, sizeof(hdr), 1, f));
+    hdr.flags = kDataFileHasCosineInvNorms;
+    hdr.vector_stride = static_cast<uint32_t>(compute_vector_size(DataType::f32, hdr.dim));
+    rewind(f);
+    ASSERT_EQ(1u, fwrite(&hdr, sizeof(hdr), 1, f));
+    fclose(f);
+
+    DataReader r;
+    const Ret ret = r.init(data_path_);
+    EXPECT_NE(0, ret.code());
+    EXPECT_NE(std::string::npos, ret.message().find("invalid inline norm layout"));
 }
 
 TEST_F(DataReaderTest, FailsOnLegacyRawIdsTrailer) {

--- a/src/core/storage/utest_data_reader.cpp
+++ b/src/core/storage/utest_data_reader.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <vector>
 #include <fstream>
+#include "core/compute/norm_utils.h"
 #include "core/storage/data_file.h"
 #include "core/storage/data_file_layout.h"
 #include "core/storage/input_generator.h"
@@ -113,7 +114,8 @@ protected:
     // Write a minimal valid binary data file with vector bytes and compact id trailer.
     // type_field: 0=f16, 1=f32, 2=i16  (matches DataWriter encoding)
     void write_raw(DataType type_field, uint16_t dim, uint64_t min_id,
-                   const std::vector<std::vector<uint8_t>>& vecs) {
+                   const std::vector<std::vector<uint8_t>>& vecs,
+                   uint32_t norm_flags = 0) {
         CompactIds compact_ids;
         std::vector<uint64_t> ids;
         ids.reserve(vecs.size());
@@ -131,7 +133,8 @@ protected:
             static_cast<uint32_t>(vecs.size()),
             0,
             type_field,
-            dim);
+            dim,
+            norm_flags);
         ASSERT_EQ(0, set_data_header_layout(
             &hdr, compact_ids.serialized_size_bytes(), compact_deleted_ids.serialized_size_bytes()).code());
         FILE* f = fopen(data_path_.c_str(), "wb");
@@ -141,8 +144,22 @@ protected:
             std::vector<uint8_t> pad(pad_size, 0);
             fwrite(pad.data(), 1, pad.size(), f);
         }
+        const DataRecordLayout record_layout = compute_data_record_layout(type_field, dim, norm_flags != 0);
         for (const auto& v : vecs) {
-            ASSERT_EQ(0, write_vector_record(f, v.data(), v.size(), hdr.vector_stride, "DataReaderTest::write_raw").code());
+            float norm = 0.0f;
+            float* norm_ptr = nullptr;
+            if (norm_flags != 0) {
+                if (norm_flags == kDataFileHasCosineInvNorms) {
+                    norm = compute_cosine_inverse_norm(v.data(), type_field, dim);
+                } else if (norm_flags == kDataFileHasSquaredNorms) {
+                    norm = compute_squared_norm(v.data(), type_field, dim);
+                } else {
+                    FAIL() << "write_raw: invalid stored norm flags";
+                }
+                norm_ptr = &norm;
+            }
+            ASSERT_EQ(0, write_data_record(
+                f, v.data(), record_layout, norm_ptr, "DataReaderTest::write_raw").code());
         }
         const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr, vecs.size());
         const size_t ids_pad_size = metadata_layout.vectors_padding;
@@ -462,6 +479,28 @@ TEST_F(DataReaderTest, ReadsL2NormValuesFromInlineRecords) {
     EXPECT_NEAR(static_cast<double>(r.get_norm(0)), static_cast<double>(it.get_norm()), 1e-6);
 }
 
+TEST_F(DataReaderTest, WriteRawSupportsInlineNormsForI16) {
+    const std::vector<int16_t> vec0 = {3, 3, 3, 3};
+    const std::vector<int16_t> vec1 = {4, 4, 4, 4};
+    const std::vector<std::vector<uint8_t>> vecs = {
+        std::vector<uint8_t>(reinterpret_cast<const uint8_t*>(vec0.data()),
+            reinterpret_cast<const uint8_t*>(vec0.data()) + vec0.size() * sizeof(int16_t)),
+        std::vector<uint8_t>(reinterpret_cast<const uint8_t*>(vec1.data()),
+            reinterpret_cast<const uint8_t*>(vec1.data()) + vec1.size() * sizeof(int16_t))
+    };
+
+    write_raw(DataType::i16, 4, 7, vecs, kDataFileHasSquaredNorms);
+
+    DataReader r;
+    ASSERT_EQ(0, r.init(data_path_).code());
+    ASSERT_TRUE(r.has_norms());
+    EXPECT_TRUE(r.has_matching_stored_norms(DistFunc::L2));
+    EXPECT_FALSE(r.has_matching_stored_norms(DistFunc::COS));
+    EXPECT_GT(r.stride(), r.size());
+    EXPECT_FLOAT_EQ(36.0f, r.get_norm(0));
+    EXPECT_FLOAT_EQ(64.0f, r.get_norm(1));
+}
+
 TEST_F(DataReaderTest, EmptyDataFileInitSucceeds) {
     DataFileHeader hdr = make_data_header(0, 0, 0, 0, DataType::f32, 4);
     CompactIds compact_ids;
@@ -577,13 +616,28 @@ TEST_F(DataReaderTest, AtI16VectorDataIsCorrect) {
     }
 }
 
-TEST_F(DataReaderTest, AtConsecutivePointersSpacedBySize) {
+TEST_F(DataReaderTest, AtConsecutivePointersSpacedByStride) {
     generate(4, 0, DataType::f32, 8);
     DataReader r;
     EXPECT_EQ(0, r.init(data_path_).code());
     for (size_t i = 0; i < 3; ++i) {
         ptrdiff_t gap = r.at(i + 1) - r.at(i);
-        EXPECT_EQ(static_cast<ptrdiff_t>(r.size()), gap) << "at index " << i;
+        EXPECT_EQ(static_cast<ptrdiff_t>(r.stride()), gap) << "at index " << i;
+    }
+}
+
+TEST_F(DataReaderTest, AtConsecutivePointersSpacedByStrideWithInlineNorms) {
+    GeneratorConfig cfg{PatternType::Sequential, 4, 0, DataType::f32, 8, 1000};
+    generate_input_file(input_path_, cfg);
+    DataWriter w;
+    ASSERT_EQ(0, w.exec_for_testing(input_path_, data_path_, 0, 0, DistFunc::COS).code());
+
+    DataReader r;
+    ASSERT_EQ(0, r.init(data_path_).code());
+    ASSERT_GT(r.stride(), r.size());
+    for (size_t i = 0; i < 3; ++i) {
+        ptrdiff_t gap = r.at(i + 1) - r.at(i);
+        EXPECT_EQ(static_cast<ptrdiff_t>(r.stride()), gap) << "at index " << i;
     }
 }
 

--- a/src/core/storage/utest_data_reader.cpp
+++ b/src/core/storage/utest_data_reader.cpp
@@ -313,6 +313,71 @@ TEST_F(DataReaderTest, FailsWhenInlineNormDoesNotFitStride) {
     EXPECT_NE(std::string::npos, ret.message().find("invalid inline norm layout"));
 }
 
+TEST_F(DataReaderTest, FailsWhenInlineNormUsesNonCanonicalStride) {
+    const uint16_t dim = 5;
+    const DataType type = DataType::f32;
+    const DataRecordLayout canonical_layout = compute_data_record_layout(type, dim, true);
+    const size_t shifted_norm_offset = canonical_layout.norm_offset + kDataAlignment;
+    const size_t noncanonical_stride = canonical_layout.stride + kDataAlignment;
+
+    CompactIds compact_ids;
+    ASSERT_EQ(0, compact_ids.init(std::vector<uint64_t>{7}).code());
+    CompactIds compact_deleted_ids;
+    ASSERT_EQ(0, compact_deleted_ids.init(std::vector<uint64_t>{}).code());
+
+    DataFileHeader hdr = make_data_header(7, 7, 1, 0, type, dim, kDataFileHasCosineInvNorms);
+    hdr.vector_stride = static_cast<uint32_t>(noncanonical_stride);
+    ASSERT_EQ(0, set_data_header_layout(
+        &hdr, compact_ids.serialized_size_bytes(), compact_deleted_ids.serialized_size_bytes()).code());
+
+    FILE* f = fopen(data_path_.c_str(), "wb");
+    ASSERT_NE(nullptr, f);
+    ASSERT_EQ(1u, fwrite(&hdr, sizeof(hdr), 1, f));
+    const size_t header_padding = static_cast<size_t>(hdr.data_offset) - sizeof(DataFileHeader);
+    if (header_padding > 0) {
+        std::vector<uint8_t> pad(header_padding, 0);
+        ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
+    }
+
+    const std::vector<float> vector_values = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    ASSERT_EQ(canonical_layout.vector_size, vector_values.size() * sizeof(float));
+    ASSERT_EQ(vector_values.size(), fwrite(vector_values.data(), sizeof(float), vector_values.size(), f));
+    const size_t bytes_before_shifted_norm = shifted_norm_offset - canonical_layout.vector_size;
+    if (bytes_before_shifted_norm > 0) {
+        std::vector<uint8_t> pad(bytes_before_shifted_norm, 0);
+        ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
+    }
+    const float norm = static_cast<float>(compute_cosine_inverse_norm(
+        reinterpret_cast<const uint8_t*>(vector_values.data()), type, dim));
+    ASSERT_EQ(1u, fwrite(&norm, sizeof(norm), 1, f));
+    const size_t bytes_after_norm = noncanonical_stride - (shifted_norm_offset + sizeof(norm));
+    if (bytes_after_norm > 0) {
+        std::vector<uint8_t> pad(bytes_after_norm, 0);
+        ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
+    }
+
+    const DataMetadataLayout metadata_layout = compute_data_metadata_layout(hdr, 1);
+    if (metadata_layout.vectors_padding > 0) {
+        std::vector<uint8_t> pad(metadata_layout.vectors_padding, 0);
+        ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
+    }
+    ASSERT_EQ(0, compact_ids.write(f, "DataReaderTest::FailsWhenInlineNormUsesNonCanonicalStride ids").code());
+    const size_t deleted_ids_padding =
+        compute_deleted_ids_padding(metadata_layout.ids_trailer_offset, compact_ids.serialized_size_bytes());
+    if (deleted_ids_padding > 0) {
+        std::vector<uint8_t> pad(deleted_ids_padding, 0);
+        ASSERT_EQ(pad.size(), fwrite(pad.data(), 1, pad.size(), f));
+    }
+    ASSERT_EQ(0, compact_deleted_ids.write(
+        f, "DataReaderTest::FailsWhenInlineNormUsesNonCanonicalStride deleted ids").code());
+    fclose(f);
+
+    DataReader r;
+    const Ret ret = r.init(data_path_);
+    EXPECT_NE(0, ret.code());
+    EXPECT_NE(std::string::npos, ret.message().find("invalid inline norm layout"));
+}
+
 TEST_F(DataReaderTest, FailsOnLegacyRawIdsTrailer) {
     const std::vector<std::vector<uint8_t>> vecs = {
         std::vector<uint8_t>(4 * sizeof(float), 0),

--- a/src/core/storage/utest_data_reader.cpp
+++ b/src/core/storage/utest_data_reader.cpp
@@ -409,7 +409,7 @@ TEST_F(DataReaderTest, CountIsCorrect) {
     EXPECT_EQ(7u, r.count());
 }
 
-TEST_F(DataReaderTest, GetNormThrowsWhenNormsSectionIsAbsent) {
+TEST_F(DataReaderTest, GetNormThrowsWhenInlineNormsAreAbsent) {
     generate(2, 0, DataType::f32, 4);
     DataReader r;
     ASSERT_EQ(0, r.init(data_path_).code());
@@ -422,7 +422,7 @@ TEST_F(DataReaderTest, GetNormThrowsWhenNormsSectionIsAbsent) {
     EXPECT_THROW(static_cast<void>(it.get_norm()), std::logic_error);
 }
 
-TEST_F(DataReaderTest, ReadsCosineValuesWhenSectionIsPresent) {
+TEST_F(DataReaderTest, ReadsCosineValuesFromInlineRecords) {
     GeneratorConfig cfg{PatternType::Sequential, 2, 0, DataType::f32, 4, 1000};
     generate_input_file(input_path_, cfg);
     DataWriter w;
@@ -442,7 +442,7 @@ TEST_F(DataReaderTest, ReadsCosineValuesWhenSectionIsPresent) {
     EXPECT_NEAR(static_cast<double>(r.get_norm(0)), static_cast<double>(it.get_norm()), 1e-6);
 }
 
-TEST_F(DataReaderTest, ReadsL2NormValuesWhenSectionIsPresent) {
+TEST_F(DataReaderTest, ReadsL2NormValuesFromInlineRecords) {
     GeneratorConfig cfg{PatternType::Sequential, 2, 0, DataType::f32, 4, 1000};
     generate_input_file(input_path_, cfg);
     DataWriter w;

--- a/src/core/storage/utest_data_writer.cpp
+++ b/src/core/storage/utest_data_writer.cpp
@@ -556,8 +556,6 @@ TEST_F(DataWriterTest, DotOutputDoesNotGrowBeyondNormalStridePadding) {
     EXPECT_FALSE(data_file_has_norms(hdr));
     EXPECT_EQ(layout.stride, hdr.vector_stride);
     EXPECT_EQ(32u, hdr.vector_stride);
-    EXPECT_EQ(0u, hdr.norms_offset);
-    EXPECT_EQ(0u, hdr.norms_bytes);
 }
 
 TEST_F(DataWriterTest, CosineValuesAreWrittenInlineWithVectorRecords) {

--- a/src/core/storage/utest_data_writer.cpp
+++ b/src/core/storage/utest_data_writer.cpp
@@ -233,7 +233,7 @@ protected:
         return data;
     }
 
-    std::vector<float> read_norms(size_t count) {
+    std::vector<float> read_inline_norms(size_t count) {
         std::vector<float> values(count);
         FILE* f = fopen(output_path_.c_str(), "rb");
         if (f) {
@@ -560,13 +560,13 @@ TEST_F(DataWriterTest, DotOutputDoesNotGrowBeyondNormalStridePadding) {
     EXPECT_EQ(0u, hdr.norms_bytes);
 }
 
-TEST_F(DataWriterTest, CosineValuesAreWrittenInlineWithVectors) {
+TEST_F(DataWriterTest, CosineValuesAreWrittenInlineWithVectorRecords) {
     ASSERT_EQ(0, run(2, 0, DataType::f32, 4, 0, DistFunc::COS).code());
     const auto hdr = read_header();
     ASSERT_TRUE(data_file_has_norms(hdr));
     EXPECT_TRUE(data_file_has_cosine_inv_norms(hdr));
 
-    const auto norms = read_norms(hdr.count);
+    const auto norms = read_inline_norms(hdr.count);
     ASSERT_EQ(2u, norms.size());
     const float inv_norm0 = 1.0f / std::sqrt(4.0f * 0.1f * 0.1f);
     const float inv_norm1 = 1.0f / std::sqrt(4.0f * 1.1f * 1.1f);
@@ -589,19 +589,19 @@ TEST_F(DataWriterTest, CosineValuesAreWrittenInlineWithVectors) {
     }
 }
 
-TEST_F(DataWriterTest, CosineValuesAreWrittenInlineForI16) {
+TEST_F(DataWriterTest, CosineValuesAreWrittenInlineForI16Records) {
     ASSERT_EQ(0, run(2, 0, DataType::i16, 4, 0, DistFunc::COS).code());
     const auto hdr = read_header();
     ASSERT_TRUE(data_file_has_norms(hdr));
     EXPECT_TRUE(data_file_has_cosine_inv_norms(hdr));
 
-    const auto norms = read_norms(hdr.count);
+    const auto norms = read_inline_norms(hdr.count);
     ASSERT_EQ(2u, norms.size());
     EXPECT_FLOAT_EQ(0.0f, norms[0]);
     EXPECT_NEAR(1.0f / std::sqrt(4.0f), norms[1], 1e-6f);
 }
 
-TEST_F(DataWriterTest, L2ValuesAreWrittenInlineWithVectors) {
+TEST_F(DataWriterTest, L2ValuesAreWrittenInlineWithVectorRecords) {
     GeneratorConfig cfg{PatternType::Sequential, 2, 0, DataType::f32, 4, 1000};
     generate_input_file(input_path_, cfg);
     DataWriter w;
@@ -611,7 +611,7 @@ TEST_F(DataWriterTest, L2ValuesAreWrittenInlineWithVectors) {
     ASSERT_TRUE(data_file_has_norms(hdr));
     EXPECT_TRUE(data_file_has_squared_norms(hdr));
 
-    const auto norms = read_norms(hdr.count);
+    const auto norms = read_inline_norms(hdr.count);
     ASSERT_EQ(2u, norms.size());
     EXPECT_NEAR(4.0f * 0.1f * 0.1f, norms[0], 1e-6f);
     EXPECT_NEAR(4.0f * 1.1f * 1.1f, norms[1], 1e-6f);

--- a/src/core/storage/utest_data_writer.cpp
+++ b/src/core/storage/utest_data_writer.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 #include <cmath>
 #include <fstream>
 #include <unistd.h>
@@ -239,13 +240,36 @@ protected:
             DataFileHeader hdr{};
             auto sz = fread(&hdr, sizeof(hdr), 1, f);
             (void)sz;
-            const DataMetadataLayout layout = compute_data_metadata_layout(hdr, count);
-            fseek(f, static_cast<long>(layout.norms_offset), SEEK_SET);
-            sz = fread(values.data(), sizeof(float), count, f);
-            (void)sz;
+            const DataRecordLayout record_layout = compute_data_record_layout(
+                data_type_from_int(static_cast<int>(hdr.type)), hdr.dim, data_file_has_norms(hdr));
+            for (size_t i = 0; i < count; ++i) {
+                const long norm_pos = static_cast<long>(
+                    hdr.data_offset + i * static_cast<size_t>(hdr.vector_stride) + record_layout.norm_offset);
+                fseek(f, norm_pos, SEEK_SET);
+                sz = fread(&values[i], sizeof(float), 1, f);
+                (void)sz;
+            }
             fclose(f);
         }
         return values;
+    }
+
+    std::vector<uint8_t> read_record_bytes(size_t index) {
+        std::vector<uint8_t> bytes;
+        FILE* f = fopen(output_path_.c_str(), "rb");
+        if (f) {
+            DataFileHeader hdr{};
+            auto sz = fread(&hdr, sizeof(hdr), 1, f);
+            (void)sz;
+            bytes.resize(hdr.vector_stride);
+            if (!bytes.empty()) {
+                fseek(f, static_cast<long>(hdr.data_offset + index * static_cast<size_t>(hdr.vector_stride)), SEEK_SET);
+                sz = fread(bytes.data(), 1, bytes.size(), f);
+                (void)sz;
+            }
+            fclose(f);
+        }
+        return bytes;
     }
 
     CompactIdsExtEncoding read_compact_encoding_at(size_t offset) {
@@ -525,7 +549,18 @@ TEST_F(DataWriterTest, BinaryInputVectorDataIsCorrect) {
     }
 }
 
-TEST_F(DataWriterTest, CosineValuesSectionIsWritten) {
+TEST_F(DataWriterTest, DotOutputDoesNotGrowBeyondNormalStridePadding) {
+    ASSERT_EQ(0, run(2, 0, DataType::f32, 8, 0, DistFunc::DOT).code());
+    const auto hdr = read_header();
+    const auto layout = compute_data_record_layout(DataType::f32, 8, false);
+    EXPECT_FALSE(data_file_has_norms(hdr));
+    EXPECT_EQ(layout.stride, hdr.vector_stride);
+    EXPECT_EQ(32u, hdr.vector_stride);
+    EXPECT_EQ(0u, hdr.norms_offset);
+    EXPECT_EQ(0u, hdr.norms_bytes);
+}
+
+TEST_F(DataWriterTest, CosineValuesAreWrittenInlineWithVectors) {
     ASSERT_EQ(0, run(2, 0, DataType::f32, 4, 0, DistFunc::COS).code());
     const auto hdr = read_header();
     ASSERT_TRUE(data_file_has_norms(hdr));
@@ -537,9 +572,24 @@ TEST_F(DataWriterTest, CosineValuesSectionIsWritten) {
     const float inv_norm1 = 1.0f / std::sqrt(4.0f * 1.1f * 1.1f);
     EXPECT_NEAR(inv_norm0, norms[0], 1e-5f);
     EXPECT_NEAR(inv_norm1, norms[1], 1e-5f);
+
+    const auto record_layout = compute_data_record_layout(DataType::f32, 4, true);
+    const auto record0 = read_record_bytes(0);
+    ASSERT_EQ(static_cast<size_t>(hdr.vector_stride), record0.size());
+
+    float persisted_norm0 = 0.0f;
+    std::memcpy(&persisted_norm0, record0.data() + record_layout.norm_offset, sizeof(persisted_norm0));
+    EXPECT_NEAR(inv_norm0, persisted_norm0, 1e-5f);
+
+    for (size_t i = record_layout.vector_size; i < record_layout.norm_offset; ++i) {
+        EXPECT_EQ(0u, record0[i]);
+    }
+    for (size_t i = record_layout.norm_offset + sizeof(float); i < record0.size(); ++i) {
+        EXPECT_EQ(0u, record0[i]);
+    }
 }
 
-TEST_F(DataWriterTest, CosineValuesSectionIsWrittenForI16) {
+TEST_F(DataWriterTest, CosineValuesAreWrittenInlineForI16) {
     ASSERT_EQ(0, run(2, 0, DataType::i16, 4, 0, DistFunc::COS).code());
     const auto hdr = read_header();
     ASSERT_TRUE(data_file_has_norms(hdr));
@@ -551,7 +601,7 @@ TEST_F(DataWriterTest, CosineValuesSectionIsWrittenForI16) {
     EXPECT_NEAR(1.0f / std::sqrt(4.0f), norms[1], 1e-6f);
 }
 
-TEST_F(DataWriterTest, L2ValuesSectionIsWritten) {
+TEST_F(DataWriterTest, L2ValuesAreWrittenInlineWithVectors) {
     GeneratorConfig cfg{PatternType::Sequential, 2, 0, DataType::f32, 4, 1000};
     generate_input_file(input_path_, cfg);
     DataWriter w;
@@ -565,6 +615,14 @@ TEST_F(DataWriterTest, L2ValuesSectionIsWritten) {
     ASSERT_EQ(2u, norms.size());
     EXPECT_NEAR(4.0f * 0.1f * 0.1f, norms[0], 1e-6f);
     EXPECT_NEAR(4.0f * 1.1f * 1.1f, norms[1], 1e-6f);
+
+    const auto record_layout = compute_data_record_layout(DataType::f32, 4, true);
+    const auto record1 = read_record_bytes(1);
+    ASSERT_EQ(static_cast<size_t>(hdr.vector_stride), record1.size());
+
+    float persisted_norm1 = 0.0f;
+    std::memcpy(&persisted_norm1, record1.data() + record_layout.norm_offset, sizeof(persisted_norm1));
+    EXPECT_NEAR(4.0f * 1.1f * 1.1f, persisted_norm1, 1e-6f);
 }
 
 TEST_F(DataWriterTest, UnsortedInputIsWrittenInSortedIdOrder) {

--- a/src/core/utils/compute_unit.cpp
+++ b/src/core/utils/compute_unit.cpp
@@ -1,4 +1,4 @@
-// Defines runtime calc-engine selection helpers.
+// Defines runtime compute engine selection helpers.
 
 #include "compute_unit.h"
 
@@ -20,7 +20,7 @@ ComputeBackendKind detect_best_backend() {
 ComputeUnit ComputeUnit::detect_best() {
     const ComputeBackendKind detected = detect_best_backend();
     LOG_INFO << "Compute backend set to '" << ComputeUnit(detected).name()
-             << "' because it is the default calc engine.";
+             << "' because it is the default compute engine.";
     return ComputeUnit(detected);
 }
 

--- a/src/core/utils/dynamic_bitset.h
+++ b/src/core/utils/dynamic_bitset.h
@@ -16,14 +16,49 @@ class DynamicBitset {
 public:
     void resize(size_t size);
     size_t size() const { return bit_count_; }
+    bool empty() const { return bit_count_ == 0; }
     bool get(size_t index) const {
         if (index >= bit_count_) {
             throw std::out_of_range("DynamicBitset::get: index out of range");
         }
 
+        return get_unchecked(index);
+    }
+    bool get_unchecked(size_t index) const {
         const size_t word_index = index / kWordBits;
         const size_t bit_index = index % kWordBits;
         return (words_[word_index] & (uint64_t{1} << bit_index)) != 0;
+    }
+    bool any() const {
+        for (uint64_t word : words_) {
+            if (word != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+    size_t find_next_unset(size_t index) const {
+        if (index >= bit_count_) {
+            return bit_count_;
+        }
+
+        size_t word_index = index / kWordBits;
+        uint64_t clear_bits = ~words_[word_index];
+        clear_bits &= ~((uint64_t{1} << (index % kWordBits)) - 1);
+
+        while (true) {
+            if (clear_bits != 0) {
+                const size_t candidate =
+                    word_index * kWordBits + static_cast<size_t>(__builtin_ctzll(clear_bits));
+                return candidate < bit_count_ ? candidate : bit_count_;
+            }
+
+            ++word_index;
+            if (word_index >= words_.size()) {
+                return bit_count_;
+            }
+            clear_bits = ~words_[word_index];
+        }
     }
     void set(size_t index, bool value = true);
     void append(uint64_t word) {

--- a/src/core/utils/shared_consts.h
+++ b/src/core/utils/shared_consts.h
@@ -39,8 +39,8 @@ inline constexpr uint64_t kDataRegionAlignment = 4096;
 // Id section alignment used by data-file layout code when placing CompactIdsOffsets trailer sections.
 inline constexpr uint32_t kIdsAlignment = 8;
 
-// Data-file header flags describing which float values are persisted in the
-// optional norms section for active vectors.
+// Data-file header flags describing which float values are persisted inline in
+// active vector records.
 inline constexpr uint32_t kDataFileHasCosineInvNorms = 1u;
 inline constexpr uint32_t kDataFileHasSquaredNorms = 2u;
 inline constexpr uint32_t kDataFileNormKindMask =

--- a/src/core/utils/shared_consts.h
+++ b/src/core/utils/shared_consts.h
@@ -26,9 +26,9 @@ inline constexpr uint64_t kMaxDimension = 4096;
 inline constexpr uint32_t kMagic = 0x534B5632; // "SKV2"
 
 // Binary storage format version written into data/WAL headers and checked when reopening files.
-// Version 11 stores aligned vector records with any optional norm inline in the record stride,
+// Version 12 stores aligned vector records with any optional norm inline in the record stride,
 // followed by ids and deleted-ids trailers.
-inline constexpr uint16_t kVersion = 11;
+inline constexpr uint16_t kVersion = 12;
 
 // Vector payload alignment used by data files and accumulator storage for SIMD-friendly access.
 inline constexpr uint32_t kDataAlignment = 32;

--- a/src/core/utils/shared_consts.h
+++ b/src/core/utils/shared_consts.h
@@ -26,9 +26,9 @@ inline constexpr uint64_t kMaxDimension = 4096;
 inline constexpr uint32_t kMagic = 0x534B5632; // "SKV2"
 
 // Binary storage format version written into data/WAL headers and checked when reopening files.
-// Version 10 stores explicit 64-bit offsets and sizes for all independently mappable sections,
-// including the vectors section itself.
-inline constexpr uint16_t kVersion = 10;
+// Version 11 stores aligned vector records with any optional norm inline in the record stride,
+// followed by ids and deleted-ids trailers.
+inline constexpr uint16_t kVersion = 11;
 
 // Vector payload alignment used by data files and accumulator storage for SIMD-friendly access.
 inline constexpr uint32_t kDataAlignment = 32;

--- a/src/core/utils/utest_dynamic_bitset.cpp
+++ b/src/core/utils/utest_dynamic_bitset.cpp
@@ -87,4 +87,32 @@ TEST(dynamic_bitset, word_boundary_bits_do_not_bleed) {
     EXPECT_TRUE(bitset.get(64));  // clearing 63 must not affect 64
 }
 
+TEST(dynamic_bitset, find_next_unset_skips_runs_of_set_bits) {
+    DynamicBitset bitset;
+    bitset.resize(130);
+
+    for (size_t i = 0; i < 70; ++i) {
+        bitset.set(i);
+    }
+    bitset.set(90);
+    bitset.set(91);
+
+    EXPECT_EQ(70u, bitset.find_next_unset(0));
+    EXPECT_EQ(70u, bitset.find_next_unset(64));
+    EXPECT_EQ(70u, bitset.find_next_unset(70));
+    EXPECT_EQ(92u, bitset.find_next_unset(90));
+}
+
+TEST(dynamic_bitset, find_next_unset_returns_size_when_no_clear_bits_remain) {
+    DynamicBitset bitset;
+    bitset.resize(70);
+    for (size_t i = 0; i < bitset.size(); ++i) {
+        bitset.set(i);
+    }
+
+    EXPECT_EQ(bitset.size(), bitset.find_next_unset(0));
+    EXPECT_EQ(bitset.size(), bitset.find_next_unset(69));
+    EXPECT_EQ(bitset.size(), bitset.find_next_unset(bitset.size()));
+}
+
 } // namespace sketch2

--- a/tests/compute_perf/common.py
+++ b/tests/compute_perf/common.py
@@ -198,6 +198,14 @@ def load_ground_truth(config: PerfConfig, dist_func: str) -> tuple[list[int], li
     return data["ids"], score_values
 
 
+def tree_size_bytes(path: Path) -> int:
+    total = 0
+    for child in path.rglob("*"):
+        if child.is_file():
+            total += child.stat().st_size
+    return total
+
+
 def distance_helpers(
     dist_func: str,
 ) -> tuple[

--- a/tests/compute_perf/reporter.py
+++ b/tests/compute_perf/reporter.py
@@ -11,6 +11,7 @@ from common import load_config
 
 REPORT_METRIC_RE = re.compile(r"^Metric:\s*(\S+)\s*$")
 REPORT_AVG_RE = re.compile(r"^Avg Time:\s*([0-9]+(?:\.[0-9]+)?)s\s*$")
+REPORT_SIZE_RE = re.compile(r"^Dataset Size:\s*([0-9]+)\s+bytes\s*$")
 KERNEL_CASE_RE = re.compile(
     r"^Kernel Case:\s+(\S+)\s+avg=([0-9]+(?:\.[0-9]+)?)ns\s+min=([0-9]+(?:\.[0-9]+)?)ns\s+max=([0-9]+(?:\.[0-9]+)?)ns\s*$"
 )
@@ -63,6 +64,26 @@ def parse_kernel_log(path: Path, case_name: str = "dist") -> dict[str, float]:
             case_match = KERNEL_CASE_RE.match(line)
             if case_match and pending_dist is not None and case_match.group(1) == case_name:
                 results[pending_dist] = float(case_match.group(2))
+                pending_dist = None
+
+    return results
+
+
+def parse_dataset_size_log(path: Path) -> dict[str, int]:
+    results: dict[str, int] = {}
+    pending_dist: str | None = None
+
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            dist_match = REPORT_METRIC_RE.match(line)
+            if dist_match:
+                pending_dist = dist_match.group(1).lower()
+                continue
+
+            size_match = REPORT_SIZE_RE.match(line)
+            if size_match and pending_dist is not None:
+                results[pending_dist] = int(size_match.group(1))
                 pending_dist = None
 
     return results
@@ -134,6 +155,27 @@ def main() -> None:
     print("--- KERNEL SUMMARY (metric avg ns/call) ---")
     print(build_table(headers, kernel_rows))
     print("-----------------------------------------")
+
+    size_rows: list[list[str]] = []
+    for engine in config.compute_engines:
+        row = [engine]
+        for dist in config.dist_funcs:
+            dist_path = runner_dist_log_path(config, engine, dist)
+            if dist_path.exists():
+                metrics = parse_dataset_size_log(dist_path)
+                size_bytes = metrics.get(dist)
+                row.append("-" if size_bytes is None else str(size_bytes))
+                continue
+
+            path = runner_log_path(config, engine)
+            metrics = parse_dataset_size_log(path) if path.exists() else {}
+            size_bytes = metrics.get(dist)
+            row.append("-" if size_bytes is None else str(size_bytes))
+        size_rows.append(row)
+
+    print("--- DATASET SIZE SUMMARY (bytes) ---")
+    print(build_table(headers, size_rows))
+    print("------------------------------------")
 
 
 if __name__ == "__main__":

--- a/tests/compute_perf/runner.py
+++ b/tests/compute_perf/runner.py
@@ -22,6 +22,7 @@ from common import (
     fmt_typed_vector,
     load_ground_truth,
     query_values_for_dist,
+    tree_size_bytes,
     validate_knn_results
 )
 
@@ -120,6 +121,7 @@ def write_repro_scripts(config, dist: str) -> None:
 
 def initial_diag_state(config, dist: str, query_vals: list[float | int], query_str: str) -> dict:
     dataset_name = f"{config.dataset}_{dist}"
+    dataset_dir = config.db_dir / dataset_name
     return {
         "status": "running",
         "stage": "initialized",
@@ -129,7 +131,8 @@ def initial_diag_state(config, dist: str, query_vals: list[float | int], query_s
         "db_dir": str(config.db_dir),
         "config_path": str(config.db_dir / "config.ini"),
         "dataset_name": dataset_name,
-        "dataset_dir": str(config.db_dir / dataset_name),
+        "dataset_dir": str(dataset_dir),
+        "dataset_size_bytes": tree_size_bytes(dataset_dir),
         "dataset_ini": str(config.db_dir / dataset_name / f"{dataset_name}.ini"),
         "ground_truth_path": str(config.db_dir / f"ground_truth_{dist}.json"),
         "repeat": config.repeat,
@@ -361,6 +364,7 @@ def run_single_distance(dist: str) -> None:
             print(f"Min Time:       {min_t:.6f}s")
             print(f"Max Time:       {max_t:.6f}s")
             print(f"Avg Time:       {avg_t:.6f}s")
+            print(f"Dataset Size:   {diag_state['dataset_size_bytes']} bytes")
             print(f"--------------------------")
 
 


### PR DESCRIPTION
Fixing performance issues:
 - Change data layout in files - now norms are stored right after vector data, which improves data access speed
 - Added multiple "*_unchecked" functions that allow data access without checking validity of pointers when it was already checked
 - Replaced function pointers with templated functions to allow compiler optimization


--- Control perf test result 0.297559s 
--- Perf test result after previous code change  0.328193s  
--- Perf test result after applying multiple optimization options 0.070588s  
